### PR TITLE
Allow multiple photos to be captured in quick succession

### DIFF
--- a/src/PhotoBooth.Application/Services/ICaptureWorkflowService.cs
+++ b/src/PhotoBooth.Application/Services/ICaptureWorkflowService.cs
@@ -4,16 +4,11 @@ public interface ICaptureWorkflowService
 {
     /// <summary>
     /// Triggers a capture workflow with countdown.
+    /// Multiple triggers can be active simultaneously.
     /// </summary>
     /// <param name="triggerSource">The source that triggered the capture (e.g., "web-ui", "keyboard", "gpio").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>True if the workflow was started, false if a capture is already in progress.</returns>
-    Task<bool> TriggerCaptureAsync(string triggerSource, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets whether a capture is currently in progress.
-    /// </summary>
-    bool IsCaptureInProgress { get; }
+    Task TriggerCaptureAsync(string triggerSource, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// The configured countdown duration in milliseconds.

--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -26,12 +26,7 @@ public static class PhotoEndpoints
         ICaptureWorkflowService workflowService,
         CancellationToken cancellationToken)
     {
-        var started = await workflowService.TriggerCaptureAsync("web-ui", cancellationToken);
-
-        if (!started)
-        {
-            return Results.Conflict(new { error = "Capture already in progress" });
-        }
+        await workflowService.TriggerCaptureAsync("web-ui", cancellationToken);
 
         return Results.Accepted(value: new
         {

--- a/src/PhotoBooth.Server/wwwroot/index.html
+++ b/src/PhotoBooth.Server/wwwroot/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>photobooth-web</title>
-    <script type="module" crossorigin src="/assets/index-aYtjBSVK.js"></script>
+    <script type="module" crossorigin src="/assets/index-DQScCwqn.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BfEIEBkq.css">
   </head>
   <body>

--- a/src/PhotoBooth.Web/src/api/client.ts
+++ b/src/PhotoBooth.Web/src/api/client.ts
@@ -7,10 +7,6 @@ export async function triggerCapture(): Promise<TriggerResponse> {
     method: 'POST',
   });
 
-  if (response.status === 409) {
-    throw new Error('Capture already in progress');
-  }
-
   if (!response.ok) {
     throw new Error(`Failed to trigger capture: ${response.statusText}`);
   }

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -49,3 +49,10 @@ export interface CaptureFailedEvent {
 }
 
 export type PhotoBoothEvent = CountdownStartedEvent | PhotoCapturedEvent | CaptureFailedEvent;
+
+export interface QueuedPhoto {
+  photoId: string;
+  code: string;
+  imageUrl: string;
+  timestamp: string;
+}

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -1,34 +1,89 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Slideshow } from '../components/Slideshow';
 import { CaptureOverlay } from '../components/CaptureOverlay';
-import { PhotoDisplay } from '../components/PhotoDisplay';
+import { PhotoDisplay, type KenBurnsConfig } from '../components/PhotoDisplay';
 import { useEventStream } from '../api/events';
 import { triggerCapture } from '../api/client';
-import type { PhotoBoothEvent, PhotoCapturedEvent } from '../api/types';
+import type { PhotoBoothEvent, QueuedPhoto } from '../api/types';
 
-type BoothState =
-  | { mode: 'slideshow' }
-  | { mode: 'countdown'; durationMs: number }
-  | { mode: 'preview'; photo: PhotoCapturedEvent }
-  | { mode: 'error'; message: string };
+const PREVIEW_DURATION_MS = 8000; // Same as slideshow interval
+const ERROR_DISPLAY_MS = 3000;
+const FADE_DURATION_MS = 500;
+const WATCHDOG_RELOAD_MS = 5 * 60 * 1000;
 
-const CAPTURE_TIMEOUT_MS = 15000; // Max time to wait for capture result
-const WATCHDOG_RELOAD_MS = 5 * 60 * 1000; // Reload page after 5 minutes of no interaction
+function randomInRange(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function generateKenBurnsConfig(): KenBurnsConfig {
+  const zoomIn = Math.random() > 0.5;
+  const scaleSmall = randomInRange(1.08, 1.12);
+  const scaleLarge = randomInRange(1.18, 1.28);
+  const panAmount = randomInRange(3, 6);
+  const panDirections = [
+    { x: panAmount, y: 0 },
+    { x: -panAmount, y: 0 },
+    { x: 0, y: panAmount },
+    { x: 0, y: -panAmount },
+    { x: panAmount * 0.7, y: panAmount * 0.7 },
+    { x: -panAmount * 0.7, y: panAmount * 0.7 },
+    { x: panAmount * 0.7, y: -panAmount * 0.7 },
+    { x: -panAmount * 0.7, y: -panAmount * 0.7 },
+  ];
+  const pan = panDirections[Math.floor(Math.random() * panDirections.length)];
+  const duration = randomInRange(8, 10);
+
+  if (zoomIn) {
+    return {
+      scaleFrom: scaleSmall,
+      scaleTo: scaleLarge,
+      xFrom: '0%',
+      yFrom: '0%',
+      xTo: `${pan.x}%`,
+      yTo: `${pan.y}%`,
+      duration: `${duration.toFixed(1)}s`,
+    };
+  } else {
+    return {
+      scaleFrom: scaleLarge,
+      scaleTo: scaleSmall,
+      xFrom: '0%',
+      yFrom: '0%',
+      xTo: `${pan.x}%`,
+      yTo: `${pan.y}%`,
+      duration: `${duration.toFixed(1)}s`,
+    };
+  }
+}
+
+interface DisplayPhoto {
+  photo: QueuedPhoto;
+  kenBurns: KenBurnsConfig;
+  key: number;
+  fromQueue: boolean; // true if from queue, false if newly captured
+}
 
 export function BoothPage() {
-  const [state, setState] = useState<BoothState>({ mode: 'slideshow' });
-  const captureTimeoutRef = useRef<number | null>(null);
+  // Queue of interrupted photos waiting to be displayed (FIFO)
+  const [photoQueue, setPhotoQueue] = useState<QueuedPhoto[]>([]);
+  // Currently displaying photo
+  const [currentDisplay, setCurrentDisplay] = useState<DisplayPhoto | null>(null);
+  // Previous photo for crossfade
+  const [previousDisplay, setPreviousDisplay] = useState<DisplayPhoto | null>(null);
+  // Number of active countdowns
+  const [activeCountdowns, setActiveCountdowns] = useState(0);
+  // Error message
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Countdown duration from latest event
+  const [countdownDurationMs, setCountdownDurationMs] = useState(3000);
+
   const watchdogTimeoutRef = useRef<number | null>(null);
+  const previewTimeoutRef = useRef<number | null>(null);
+  const errorTimeoutRef = useRef<number | null>(null);
+  const photoKeyRef = useRef(0);
+  // Track the current display for use in callbacks (avoid stale closure)
+  const currentDisplayRef = useRef<DisplayPhoto | null>(null);
 
-  // Clear any pending capture timeout
-  const clearCaptureTimeout = () => {
-    if (captureTimeoutRef.current !== null) {
-      clearTimeout(captureTimeoutRef.current);
-      captureTimeoutRef.current = null;
-    }
-  };
-
-  // Reset the watchdog timer (call this on any user interaction)
   const resetWatchdog = useCallback(() => {
     if (watchdogTimeoutRef.current !== null) {
       clearTimeout(watchdogTimeoutRef.current);
@@ -39,7 +94,6 @@ export function BoothPage() {
     }, WATCHDOG_RELOAD_MS);
   }, []);
 
-  // Initialize watchdog on mount
   useEffect(() => {
     resetWatchdog();
     return () => {
@@ -49,81 +103,201 @@ export function BoothPage() {
     };
   }, [resetWatchdog]);
 
-  const handleEvent = useCallback((event: PhotoBoothEvent) => {
-    clearCaptureTimeout();
+  // Keep ref in sync with state
+  useEffect(() => {
+    currentDisplayRef.current = currentDisplay;
+  }, [currentDisplay]);
 
+  // Helper to start showing a photo
+  const startShowingPhoto = useCallback((photo: QueuedPhoto, fromQueue: boolean) => {
+    console.log('Starting to show photo:', photo.code, fromQueue ? '(from queue)' : '(newly captured)');
+
+    // Move current to previous for crossfade
+    setCurrentDisplay(prev => {
+      if (prev) {
+        setPreviousDisplay(prev);
+        setTimeout(() => setPreviousDisplay(null), FADE_DURATION_MS);
+      }
+      return prev;
+    });
+
+    photoKeyRef.current += 1;
+    const newDisplay: DisplayPhoto = {
+      photo,
+      kenBurns: generateKenBurnsConfig(),
+      key: photoKeyRef.current,
+      fromQueue,
+    };
+    setCurrentDisplay(newDisplay);
+
+    // Schedule completion
+    if (previewTimeoutRef.current !== null) {
+      clearTimeout(previewTimeoutRef.current);
+    }
+    previewTimeoutRef.current = window.setTimeout(() => {
+      console.log('Preview complete for:', photo.code);
+
+      // If it was from queue, remove it (it was shown fully)
+      if (fromQueue) {
+        setPhotoQueue(q => q.filter(p => p.photoId !== photo.photoId));
+      }
+
+      // Clear display to trigger showing next from queue or slideshow
+      setCurrentDisplay(null);
+    }, PREVIEW_DURATION_MS);
+  }, []);
+
+  // Show next photo from queue
+  const showNextFromQueue = useCallback(() => {
+    setPhotoQueue(queue => {
+      if (queue.length === 0) {
+        return queue;
+      }
+
+      const [nextPhoto] = queue;
+      // Don't remove from queue yet - will be removed when preview completes
+      startShowingPhoto(nextPhoto, true);
+      return queue;
+    });
+  }, [startShowingPhoto]);
+
+  // Process queue when conditions change
+  useEffect(() => {
+    // Start showing queue when no countdowns and nothing currently displayed
+    if (activeCountdowns === 0 && currentDisplay === null && photoQueue.length > 0) {
+      showNextFromQueue();
+    }
+  }, [activeCountdowns, currentDisplay, photoQueue.length, showNextFromQueue]);
+
+  // Handle interruption - adds current photo to queue if it was newly captured
+  const handleInterruption = useCallback(() => {
+    const display = currentDisplayRef.current;
+    if (display === null) return;
+
+    console.log('Interrupting photo:', display.photo.code, display.fromQueue ? '(from queue - stays)' : '(new - adding to queue)');
+
+    // Cancel completion timer
+    if (previewTimeoutRef.current !== null) {
+      clearTimeout(previewTimeoutRef.current);
+      previewTimeoutRef.current = null;
+    }
+
+    // If it was newly captured (not from queue), add to end of queue
+    if (!display.fromQueue) {
+      setPhotoQueue(queue => [...queue, display.photo]);
+    }
+    // If from queue, it stays in queue (we never removed it)
+
+    // Clear display
+    setCurrentDisplay(null);
+  }, []);
+
+  const handleEvent = useCallback((event: PhotoBoothEvent) => {
     switch (event.eventType) {
       case 'countdown-started':
-        setState({ mode: 'countdown', durationMs: event.durationMs });
-        // Set a timeout to recover if we don't get a result
-        captureTimeoutRef.current = window.setTimeout(() => {
-          console.warn('Capture timeout - showing error');
-          setState({ mode: 'error', message: 'Capture timed out' });
-          setTimeout(() => {
-            console.log('Timeout recovery - returning to slideshow');
-            setState({ mode: 'slideshow' });
-          }, 3000);
-        }, CAPTURE_TIMEOUT_MS);
+        console.log('Countdown started, duration:', event.durationMs);
+        setCountdownDurationMs(event.durationMs);
+        setActiveCountdowns(count => count + 1);
+
+        // Interrupt current display if any
+        handleInterruption();
         break;
-      case 'photo-captured':
-        setState({ mode: 'preview', photo: event });
-        // Return to slideshow after preview
-        setTimeout(() => setState({ mode: 'slideshow' }), 5000);
+
+      case 'photo-captured': {
+        console.log('Photo captured:', event.code);
+        setActiveCountdowns(count => Math.max(0, count - 1));
+
+        const newPhoto: QueuedPhoto = {
+          photoId: event.photoId,
+          code: event.code,
+          imageUrl: event.imageUrl,
+          timestamp: event.timestamp,
+        };
+
+        // Show immediately (not added to queue - only goes to queue if interrupted)
+        startShowingPhoto(newPhoto, false);
         break;
+      }
+
       case 'capture-failed':
-        setState({ mode: 'error', message: event.error });
-        setTimeout(() => setState({ mode: 'slideshow' }), 3000);
+        console.error('Capture failed:', event.error);
+        setActiveCountdowns(count => Math.max(0, count - 1));
+        setErrorMessage(event.error);
+        if (errorTimeoutRef.current !== null) {
+          clearTimeout(errorTimeoutRef.current);
+        }
+        errorTimeoutRef.current = window.setTimeout(() => {
+          setErrorMessage(null);
+        }, ERROR_DISPLAY_MS);
         break;
     }
-  }, []);
+  }, [handleInterruption, startShowingPhoto]);
 
   useEventStream(handleEvent);
 
   const handleTrigger = async () => {
-    resetWatchdog(); // User interaction - reset watchdog
-    console.log('Click detected, current mode:', state.mode);
-
-    if (state.mode !== 'slideshow') {
-      console.log('Ignoring click - not in slideshow mode');
-      return;
-    }
+    resetWatchdog();
+    console.log('Click detected, triggering capture...');
 
     try {
-      console.log('Triggering capture...');
       await triggerCapture();
     } catch (err) {
       console.error('Trigger error:', err);
-      if (err instanceof Error && err.message !== 'Capture already in progress') {
-        setState({ mode: 'error', message: err.message });
-        setTimeout(() => setState({ mode: 'slideshow' }), 3000);
+      setErrorMessage(err instanceof Error ? err.message : 'Failed to trigger capture');
+      if (errorTimeoutRef.current !== null) {
+        clearTimeout(errorTimeoutRef.current);
       }
+      errorTimeoutRef.current = window.setTimeout(() => {
+        setErrorMessage(null);
+      }, ERROR_DISPLAY_MS);
     }
   };
 
   const handleCountdownComplete = () => {
-    // The server handles the actual capture, we just wait for the event
+    // Server handles actual capture
   };
+
+  // Determine what to show
+  const showCapturedPhoto = currentDisplay !== null;
+  const showSlideshow = !showCapturedPhoto;
+  const showCountdown = activeCountdowns > 0;
+  const showError = errorMessage !== null;
 
   return (
     <div className="booth-page" onClick={handleTrigger}>
-      {state.mode === 'slideshow' && <Slideshow paused={false} />}
+      {/* Show slideshow when not showing captured photos */}
+      {showSlideshow && <Slideshow paused={showCountdown} />}
 
-      {state.mode === 'countdown' && (
-        <>
-          <Slideshow paused={true} />
-          <CaptureOverlay durationMs={state.durationMs} onComplete={handleCountdownComplete} />
-        </>
-      )}
-
-      {state.mode === 'preview' && (
-        <div className="preview">
-          <PhotoDisplay photoId={state.photo.photoId} code={state.photo.code} />
+      {/* Show captured photo with same Ken Burns effect as slideshow */}
+      {showCapturedPhoto && (
+        <div className="slideshow">
+          {previousDisplay && (
+            <PhotoDisplay
+              key={previousDisplay.key}
+              photoId={previousDisplay.photo.photoId}
+              code={previousDisplay.photo.code}
+              kenBurns={previousDisplay.kenBurns}
+              fadingOut
+            />
+          )}
+          <PhotoDisplay
+            key={currentDisplay.key}
+            photoId={currentDisplay.photo.photoId}
+            code={currentDisplay.photo.code}
+            kenBurns={currentDisplay.kenBurns}
+          />
         </div>
       )}
 
-      {state.mode === 'error' && (
+      {/* Countdown overlay */}
+      {showCountdown && (
+        <CaptureOverlay durationMs={countdownDurationMs} onComplete={handleCountdownComplete} />
+      )}
+
+      {/* Error overlay */}
+      {showError && (
         <div className="error-display">
-          <div className="error-message">{state.message}</div>
+          <div className="error-message">{errorMessage}</div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Remove blocking logic from backend - multiple captures can run in parallel
- Newly captured photos display immediately with Ken Burns effect (same as slideshow)
- Interrupted photos go to a FIFO queue and are shown after all captures complete
- Consistent visual styling across slideshow and captured photo display

Closes #5

## Test plan

- [x] Single capture works as before
- [x] Rapid clicks start multiple countdowns in parallel
- [x] Each captured photo displays immediately when ready
- [x] If interrupted (new click during display), photo goes to queue
- [x] After captures complete, queued photos display in FIFO order
- [x] After queue is empty, returns to random slideshow
- [x] Ken Burns effect and crossfade consistent with slideshow

🤖 Generated with [Claude Code](https://claude.com/claude-code)