### PR TITLE
Add documentation update guidance and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+<!-- Brief description of changes -->
+
+## Related Issue
+Closes #
+
+## Checklist
+- [ ] Tests pass (`dotnet test`)
+- [ ] Documentation updated (if applicable):
+  - [ ] SPEC.md (requirements/behavior changes)
+  - [ ] README.md (setup/config/user-facing changes)
+  - [ ] CLAUDE.md (technical/architecture changes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,13 @@ Always use GitHub Flow when working on issues:
 
 4. **Merge** after review (squash merge preferred for clean history)
 
+## Documentation Updates
+
+When closing issues via PR, consider updating:
+- **SPEC.md** - Functional requirements, use cases, expected behavior
+- **README.md** - Setup instructions, configuration, user-facing changes
+- **CLAUDE.md** - Technical implementation details, architecture, known issues, build commands
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
## Summary
Add process reminders to update documentation when closing issues:
- New "Documentation Updates" section in CLAUDE.md explaining when to update each doc file
- PR template with documentation checklist

## Related Issue
Closes #15

## Checklist
- [x] Tests pass (`dotnet test`) - no code changes, documentation only
- [x] Documentation updated (if applicable):
  - [ ] SPEC.md (requirements/behavior changes)
  - [ ] README.md (setup/config/user-facing changes)
  - [x] CLAUDE.md (technical/architecture changes)