### PR TITLE
Restrict trigger endpoint to localhost only

### DIFF
--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -5,12 +5,17 @@ namespace PhotoBooth.Server.Endpoints;
 
 public static class PhotoEndpoints
 {
-    public static void MapPhotoEndpoints(this IEndpointRouteBuilder app)
+    public static void MapPhotoEndpoints(this IEndpointRouteBuilder app, IEndpointFilter? triggerFilter = null)
     {
         var group = app.MapGroup("/api/photos");
 
-        group.MapPost("/trigger", TriggerCapture)
+        var triggerEndpoint = group.MapPost("/trigger", TriggerCapture)
             .WithName("TriggerCapture");
+
+        if (triggerFilter is not null)
+        {
+            triggerEndpoint.AddEndpointFilter(triggerFilter);
+        }
 
         group.MapPost("/capture", CapturePhoto)
             .WithName("CapturePhoto");

--- a/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
+++ b/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
@@ -1,0 +1,55 @@
+using System.Net;
+
+namespace PhotoBooth.Server.Filters;
+
+public class LocalhostOnlyFilter : IEndpointFilter
+{
+    private readonly bool _enabled;
+    private readonly ILogger<LocalhostOnlyFilter> _logger;
+
+    public LocalhostOnlyFilter(bool enabled, ILogger<LocalhostOnlyFilter> logger)
+    {
+        _enabled = enabled;
+        _logger = logger;
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        if (!_enabled)
+        {
+            return await next(context);
+        }
+
+        var remoteIp = context.HttpContext.Connection.RemoteIpAddress;
+
+        if (!IsLocalhost(remoteIp))
+        {
+            _logger.LogWarning("Blocked trigger request from non-localhost IP: {RemoteIp}", remoteIp);
+            return Results.Forbid();
+        }
+
+        return await next(context);
+    }
+
+    private static bool IsLocalhost(IPAddress? ipAddress)
+    {
+        if (ipAddress is null)
+        {
+            return false;
+        }
+
+        // Check for IPv4 loopback (127.0.0.1)
+        if (IPAddress.IsLoopback(ipAddress))
+        {
+            return true;
+        }
+
+        // Check for IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)
+        if (ipAddress.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(ipAddress.MapToIPv4()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -7,6 +7,7 @@ using PhotoBooth.Infrastructure.Events;
 using PhotoBooth.Infrastructure.Input;
 using PhotoBooth.Infrastructure.Storage;
 using PhotoBooth.Server.Endpoints;
+using PhotoBooth.Server.Filters;
 using Serilog;
 
 Log.Logger = new LoggerConfiguration()
@@ -147,8 +148,14 @@ else
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
+// Create localhost-only filter for trigger endpoint
+var restrictTriggerToLocalhost = builder.Configuration.GetValue<bool?>("Trigger:RestrictToLocalhost") ?? true;
+var localhostFilter = new LocalhostOnlyFilter(
+    restrictTriggerToLocalhost,
+    app.Services.GetRequiredService<ILogger<LocalhostOnlyFilter>>());
+
 // Map endpoints
-app.MapPhotoEndpoints();
+app.MapPhotoEndpoints(localhostFilter);
 app.MapSlideshowEndpoints();
 app.MapCameraEndpoints();
 app.MapEventsEndpoints();

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -29,5 +29,8 @@
   },
   "PhotoStorage": {
     "Path": ""
+  },
+  "Trigger": {
+    "RestrictToLocalhost": true
   }
 }

--- a/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
+++ b/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using PhotoBooth.Server.Filters;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public sealed class LocalhostOnlyFilterTests
+{
+    private ILogger<LocalhostOnlyFilter> _logger = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _logger = LoggerFactory.Create(builder => { }).CreateLogger<LocalhostOnlyFilter>();
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenDisabled_AllowsAllRequests()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: false, _logger);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"));
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called when filter is disabled");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_AllowsIPv4Localhost()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(IPAddress.Loopback); // 127.0.0.1
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv4 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_AllowsIPv6Localhost()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(IPAddress.IPv6Loopback); // ::1
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv6 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_AllowsIPv4MappedLoopback()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(IPAddress.Loopback.MapToIPv6()); // ::ffff:127.0.0.1
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv4-mapped IPv6 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_BlocksExternalIPv4()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"));
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called for external IP");
+        Assert.IsInstanceOfType<IResult>(result);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_BlocksExternalIPv6()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(IPAddress.Parse("2001:db8::1"));
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called for external IPv6");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_BlocksNullIP()
+    {
+        // Arrange
+        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var context = CreateContext(null);
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called when IP is null (fail-secure)");
+    }
+
+    private static EndpointFilterInvocationContext CreateContext(IPAddress? remoteIp)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = remoteIp;
+        return new DefaultEndpointFilterInvocationContext(httpContext);
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable `Trigger:RestrictToLocalhost` option (default: `true`) to restrict `/api/photos/trigger` endpoint to localhost requests only
- Implement `LocalhostOnlyFilter` endpoint filter that checks `RemoteIpAddress` and returns 403 Forbid for non-localhost IPs
- Support IPv4 loopback (127.0.0.1), IPv6 loopback (::1), and IPv4-mapped IPv6 loopback

Closes #3

## Test plan
- [x] `dotnet build` compiles without errors
- [x] `dotnet test` - all 31 tests pass (7 new tests for LocalhostOnlyFilter)
- [ ] Manual test: Run server and verify localhost requests to `/api/photos/trigger` return 202

🤖 Generated with [Claude Code](https://claude.com/claude-code)