### PR TITLE
Remove priority for recent images in slideshow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -19,7 +19,7 @@ The application has two display modes:
 When no photo is being taken, the screen shows a slideshow of photos from the current event.
 
 - Photos rotate automatically at a configurable interval
-- Selection is random, but recently taken photos are prioritized
+- Selection is uniformly random from all event photos
 - Each photo displays its download code (and optionally QR code)
 - Fullscreen display optimized for the booth monitor
 - **Ken Burns effect**: Photos display with subtle pan/zoom animations for visual interest
@@ -32,7 +32,7 @@ Triggered when a guest presses the capture button.
 - **Countdown phase**: Display countdown timer (e.g., 5, 4, 3, 2, 1) so guests can prepare
 - **Capture phase**: Take the photo
 - **Preview phase**: Display the captured photo for a few seconds
-- **Return to slideshow**: The new photo is added to rotation with high priority
+- **Return to slideshow**: The new photo is added to the random rotation
 - **Multiple captures**: Guests can trigger additional captures during countdown or preview; photos queue and display in order
 
 ## Photo Capture

--- a/src/PhotoBooth.Application/Services/ISlideshowService.cs
+++ b/src/PhotoBooth.Application/Services/ISlideshowService.cs
@@ -5,5 +5,4 @@ namespace PhotoBooth.Application.Services;
 public interface ISlideshowService
 {
     Task<SlideshowPhotoDto?> GetNextAsync(CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<SlideshowPhotoDto>> GetRecentAsync(int count, CancellationToken cancellationToken = default);
 }

--- a/src/PhotoBooth.Application/Services/SlideshowService.cs
+++ b/src/PhotoBooth.Application/Services/SlideshowService.cs
@@ -35,14 +35,6 @@ public class SlideshowService : ISlideshowService
         return ToDto(photo);
     }
 
-    public async Task<IReadOnlyList<SlideshowPhotoDto>> GetRecentAsync(int count, CancellationToken cancellationToken = default)
-    {
-        _logger.LogDebug("Getting {Count} recent photos for slideshow", count);
-        var photos = await _photoRepository.GetRecentAsync(count, cancellationToken);
-        _logger.LogDebug("Retrieved {ActualCount} recent photos", photos.Count);
-        return photos.Select(ToDto).ToList();
-    }
-
     private SlideshowPhotoDto ToDto(Photo photo)
     {
         return new SlideshowPhotoDto(

--- a/src/PhotoBooth.Domain/Interfaces/IPhotoRepository.cs
+++ b/src/PhotoBooth.Domain/Interfaces/IPhotoRepository.cs
@@ -8,7 +8,6 @@ public interface IPhotoRepository
     Task<Photo?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
     Task<Photo?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<byte[]?> GetImageDataAsync(Guid id, CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<Photo>> GetRecentAsync(int count, CancellationToken cancellationToken = default);
     Task<Photo?> GetRandomAsync(CancellationToken cancellationToken = default);
     Task<int> GetCountAsync(CancellationToken cancellationToken = default);
 }

--- a/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
+++ b/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
@@ -72,15 +72,6 @@ public class FileSystemPhotoRepository : IPhotoRepository
         return await File.ReadAllBytesAsync(photo.FilePath, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<Photo>> GetRecentAsync(int count, CancellationToken cancellationToken = default)
-    {
-        var photos = await GetPhotosAsync(cancellationToken);
-        return photos
-            .OrderByDescending(p => p.CapturedAt)
-            .Take(count)
-            .ToList();
-    }
-
     public async Task<Photo?> GetRandomAsync(CancellationToken cancellationToken = default)
     {
         var photos = await GetPhotosAsync(cancellationToken);

--- a/src/PhotoBooth.Infrastructure/Storage/InMemoryPhotoRepository.cs
+++ b/src/PhotoBooth.Infrastructure/Storage/InMemoryPhotoRepository.cs
@@ -43,18 +43,6 @@ public class InMemoryPhotoRepository : IPhotoRepository
         }
     }
 
-    public Task<IReadOnlyList<Photo>> GetRecentAsync(int count, CancellationToken cancellationToken = default)
-    {
-        lock (_lock)
-        {
-            var recent = _photos
-                .OrderByDescending(p => p.CapturedAt)
-                .Take(count)
-                .ToList();
-            return Task.FromResult<IReadOnlyList<Photo>>(recent);
-        }
-    }
-
     public Task<Photo?> GetRandomAsync(CancellationToken cancellationToken = default)
     {
         lock (_lock)

--- a/src/PhotoBooth.Server/Endpoints/SlideshowEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/SlideshowEndpoints.cs
@@ -10,9 +10,6 @@ public static class SlideshowEndpoints
 
         group.MapGet("/next", GetNextPhoto)
             .WithName("GetNextSlideshowPhoto");
-
-        group.MapGet("/recent", GetRecentPhotos)
-            .WithName("GetRecentPhotos");
     }
 
     private static async Task<IResult> GetNextPhoto(
@@ -21,14 +18,5 @@ public static class SlideshowEndpoints
     {
         var photo = await slideshowService.GetNextAsync(cancellationToken);
         return photo is null ? Results.NotFound() : Results.Ok(photo);
-    }
-
-    private static async Task<IResult> GetRecentPhotos(
-        ISlideshowService slideshowService,
-        int count = 10,
-        CancellationToken cancellationToken = default)
-    {
-        var photos = await slideshowService.GetRecentAsync(count, cancellationToken);
-        return Results.Ok(photos);
     }
 }

--- a/src/PhotoBooth.Web/src/api/client.ts
+++ b/src/PhotoBooth.Web/src/api/client.ts
@@ -45,13 +45,3 @@ export async function getNextSlideshowPhoto(): Promise<SlideshowPhotoDto | null>
 
   return response.json();
 }
-
-export async function getRecentPhotos(count = 10): Promise<SlideshowPhotoDto[]> {
-  const response = await fetch(`${API_BASE}/slideshow/recent?count=${count}`);
-
-  if (!response.ok) {
-    throw new Error(`Failed to get recent photos: ${response.statusText}`);
-  }
-
-  return response.json();
-}

--- a/tests/PhotoBooth.Application.Tests/SlideshowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/SlideshowServiceTests.cs
@@ -56,25 +56,4 @@ public sealed class SlideshowServiceTests
         // Assert
         Assert.IsNull(result);
     }
-
-    [TestMethod]
-    public async Task GetRecentAsync_ReturnsPhotosWithImageUrls()
-    {
-        // Arrange
-        var photos = new List<Photo>
-        {
-            new() { Id = Guid.NewGuid(), Code = "111111", CapturedAt = DateTime.UtcNow },
-            new() { Id = Guid.NewGuid(), Code = "222222", CapturedAt = DateTime.UtcNow.AddMinutes(-1) }
-        };
-
-        _photoRepository.PhotosToReturnRecent = photos;
-
-        // Act
-        var result = await _service.GetRecentAsync(2);
-
-        // Assert
-        Assert.HasCount(2, result);
-        Assert.AreEqual($"/api/photos/{photos[0].Id}/image", result[0].ImageUrl);
-        Assert.AreEqual($"/api/photos/{photos[1].Id}/image", result[1].ImageUrl);
-    }
 }

--- a/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoRepository.cs
+++ b/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoRepository.cs
@@ -9,7 +9,6 @@ public sealed class StubPhotoRepository : IPhotoRepository
 
     public Photo? PhotoToReturnByCode { get; set; }
     public Photo? PhotoToReturnRandom { get; set; }
-    public IReadOnlyList<Photo>? PhotosToReturnRecent { get; set; }
     public byte[]? ImageDataToReturn { get; set; }
 
     public List<Photo> SavedPhotos { get; } = [];
@@ -29,9 +28,6 @@ public sealed class StubPhotoRepository : IPhotoRepository
 
     public Task<byte[]?> GetImageDataAsync(Guid id, CancellationToken cancellationToken = default)
         => Task.FromResult(ImageDataToReturn);
-
-    public Task<IReadOnlyList<Photo>> GetRecentAsync(int count, CancellationToken cancellationToken = default)
-        => Task.FromResult(PhotosToReturnRecent ?? (IReadOnlyList<Photo>)[]);
 
     public Task<Photo?> GetRandomAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(PhotoToReturnRandom);

--- a/tests/PhotoBooth.Server.Tests/SlideshowEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/SlideshowEndpointsTests.cs
@@ -77,35 +77,4 @@ public sealed class SlideshowEndpointsTests
         Assert.IsNotNull(photo);
         Assert.IsNotNull(photo.ImageUrl);
     }
-
-    [TestMethod]
-    public async Task GetRecentPhotos_ReturnsEmptyListWhenNoPhotos()
-    {
-        // Act
-        var response = await _client.GetAsync("/api/slideshow/recent?count=5");
-
-        // Assert
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        var photos = await response.Content.ReadFromJsonAsync<List<SlideshowPhotoDto>>();
-        Assert.IsNotNull(photos);
-        Assert.IsEmpty(photos);
-    }
-
-    [TestMethod]
-    public async Task GetRecentPhotos_ReturnsPhotosInOrder()
-    {
-        // Arrange - capture some photos
-        await _client.PostAsync("/api/photos/capture", null);
-        await _client.PostAsync("/api/photos/capture", null);
-        await _client.PostAsync("/api/photos/capture", null);
-
-        // Act
-        var response = await _client.GetAsync("/api/slideshow/recent?count=2");
-
-        // Assert
-        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        var photos = await response.Content.ReadFromJsonAsync<List<SlideshowPhotoDto>>();
-        Assert.IsNotNull(photos);
-        Assert.HasCount(2, photos);
-    }
 }


### PR DESCRIPTION
## Summary
- Update SPEC.md to clarify slideshow uses uniformly random selection (no priority for recent images)
- Remove unused `/api/slideshow/recent` endpoint and related code throughout the stack
- The queueing system for interrupted display (multiple captures) remains unchanged

Closes #18

## Test plan
- [x] `dotnet build` compiles without errors
- [x] `dotnet test` - all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)