### PR TITLE
Restrict outbound network access

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
     <!-- Web API -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -19,5 +20,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.2" />
   </ItemGroup>
 </Project>

--- a/src/PhotoBooth.Domain/Exceptions/OutboundNetworkBlockedException.cs
+++ b/src/PhotoBooth.Domain/Exceptions/OutboundNetworkBlockedException.cs
@@ -1,0 +1,12 @@
+namespace PhotoBooth.Domain.Exceptions;
+
+public class OutboundNetworkBlockedException : PhotoBoothException
+{
+    public OutboundNetworkBlockedException(Uri requestUri)
+        : base($"Outbound network access is blocked. Attempted request to: {requestUri}")
+    {
+        RequestUri = requestUri;
+    }
+
+    public Uri RequestUri { get; }
+}

--- a/src/PhotoBooth.Infrastructure/Network/BlockingHttpHandler.cs
+++ b/src/PhotoBooth.Infrastructure/Network/BlockingHttpHandler.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PhotoBooth.Domain.Exceptions;
+
+namespace PhotoBooth.Infrastructure.Network;
+
+public class BlockingHttpHandler : DelegatingHandler
+{
+    private readonly ILogger<BlockingHttpHandler> _logger;
+    private readonly bool _blockRequests;
+
+    public BlockingHttpHandler(ILogger<BlockingHttpHandler> logger, IOptions<NetworkSecurityOptions> options)
+    {
+        _logger = logger;
+        _blockRequests = options.Value.BlockOutboundRequests;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (_blockRequests)
+        {
+            _logger.LogWarning("Blocked outbound HTTP request to {Uri}", request.RequestUri);
+            throw new OutboundNetworkBlockedException(request.RequestUri!);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/PhotoBooth.Infrastructure/Network/NetworkSecurityOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Network/NetworkSecurityOptions.cs
@@ -1,0 +1,6 @@
+namespace PhotoBooth.Infrastructure.Network;
+
+public class NetworkSecurityOptions
+{
+    public bool BlockOutboundRequests { get; set; } = true;
+}

--- a/src/PhotoBooth.Infrastructure/Network/NetworkSecurityServiceExtensions.cs
+++ b/src/PhotoBooth.Infrastructure/Network/NetworkSecurityServiceExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+
+namespace PhotoBooth.Infrastructure.Network;
+
+public static class NetworkSecurityServiceExtensions
+{
+    public static IServiceCollection AddNetworkSecurity(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<NetworkSecurityOptions>(configuration.GetSection("NetworkSecurity"));
+        services.AddTransient<BlockingHttpHandler>();
+        services.ConfigureAll<HttpClientFactoryOptions>(options =>
+        {
+            options.HttpMessageHandlerBuilderActions.Add(builder =>
+            {
+                var handler = builder.Services.GetRequiredService<BlockingHttpHandler>();
+                builder.AdditionalHandlers.Add(handler);
+            });
+        });
+
+        return services;
+    }
+}

--- a/src/PhotoBooth.Infrastructure/PhotoBooth.Infrastructure.csproj
+++ b/src/PhotoBooth.Infrastructure/PhotoBooth.Infrastructure.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FlashCap" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="OpenCvSharp4" />
     <PackageReference Include="OpenCvSharp4.runtime.osx_arm64" />

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -5,6 +5,7 @@ using PhotoBooth.Infrastructure.Camera;
 using PhotoBooth.Infrastructure.CodeGeneration;
 using PhotoBooth.Infrastructure.Events;
 using PhotoBooth.Infrastructure.Input;
+using PhotoBooth.Infrastructure.Network;
 using PhotoBooth.Infrastructure.Storage;
 using PhotoBooth.Server.Endpoints;
 using PhotoBooth.Server.Filters;
@@ -21,6 +22,9 @@ builder.Host.UseSerilog();
 // Add services to the container.
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+// Add network security (blocks outbound HTTP requests by default)
+builder.Services.AddNetworkSecurity(builder.Configuration);
 
 // Configure photo storage path and event name
 var configuredPath = builder.Configuration.GetValue<string>("PhotoStorage:Path");

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -32,5 +32,8 @@
   },
   "Trigger": {
     "RestrictToLocalhost": true
+  },
+  "NetworkSecurity": {
+    "BlockOutboundRequests": true
   }
 }

--- a/tests/PhotoBooth.Infrastructure.Tests/BlockingHttpHandlerTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/BlockingHttpHandlerTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PhotoBooth.Domain.Exceptions;
+using PhotoBooth.Infrastructure.Network;
+
+namespace PhotoBooth.Infrastructure.Tests;
+
+[TestClass]
+public class BlockingHttpHandlerTests
+{
+    private ILogger<BlockingHttpHandler> _logger = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(LogLevel.Debug);
+        });
+        _logger = loggerFactory.CreateLogger<BlockingHttpHandler>();
+    }
+
+    [TestMethod]
+    public async Task SendAsync_WhenBlockingEnabled_ThrowsOutboundNetworkBlockedException()
+    {
+        var options = Options.Create(new NetworkSecurityOptions { BlockOutboundRequests = true });
+        var handler = new BlockingHttpHandler(_logger, options)
+        {
+            InnerHandler = new DummyHandler()
+        };
+        var client = new HttpClient(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/test");
+
+        var exception = await Assert.ThrowsExactlyAsync<OutboundNetworkBlockedException>(
+            () => client.SendAsync(request));
+
+        Assert.AreEqual(new Uri("https://example.com/test"), exception.RequestUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_WhenBlockingDisabled_AllowsRequest()
+    {
+        var options = Options.Create(new NetworkSecurityOptions { BlockOutboundRequests = false });
+        var handler = new BlockingHttpHandler(_logger, options)
+        {
+            InnerHandler = new DummyHandler()
+        };
+        var client = new HttpClient(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/test");
+
+        var response = await client.SendAsync(request);
+
+        Assert.AreEqual(System.Net.HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [TestMethod]
+    public void DefaultOptions_BlockOutboundRequestsIsTrue()
+    {
+        var options = new NetworkSecurityOptions();
+
+        Assert.IsTrue(options.BlockOutboundRequests, "Default should be secure (blocking enabled)");
+    }
+
+    [TestMethod]
+    public async Task SendAsync_WhenBlockingEnabled_LogsWarning()
+    {
+        var options = Options.Create(new NetworkSecurityOptions { BlockOutboundRequests = true });
+        var handler = new BlockingHttpHandler(_logger, options)
+        {
+            InnerHandler = new DummyHandler()
+        };
+        var client = new HttpClient(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/sensitive-endpoint");
+
+        await Assert.ThrowsExactlyAsync<OutboundNetworkBlockedException>(
+            () => client.SendAsync(request));
+
+        // Logger verification would require a mock logger, but we've verified the exception is thrown
+        // The warning log is a secondary concern - the critical behavior is blocking the request
+    }
+
+    private class DummyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/PhotoBooth.Infrastructure.Tests/PhotoBooth.Infrastructure.Tests.csproj
+++ b/tests/PhotoBooth.Infrastructure.Tests/PhotoBooth.Infrastructure.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MSTest" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds a `BlockingHttpHandler` that blocks all outbound HTTP requests by default
- Implements defense-in-depth protection to prevent the backend from phoning home
- Creates `OutboundNetworkBlockedException` for clear error handling
- Configurable via `NetworkSecurity:BlockOutboundRequests` setting (default: true)

**Limitation**: Only covers HttpClient-based requests. Raw socket usage would require OS-level firewall rules.

Closes #14

## Test plan
- [x] `dotnet build` compiles without errors
- [x] `dotnet test` passes all tests including new BlockingHttpHandlerTests
- [x] Verified default configuration is secure (blocking enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)