### PR TITLE
Add camera initialization warmup to fix dark first photo

### DIFF
--- a/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraOptions.cs
@@ -42,4 +42,11 @@ public class OpenCvCameraOptions
     /// Preferred capture height. Set to 0 to use camera default.
     /// </summary>
     public int PreferredHeight { get; set; } = 1080;
+
+    /// <summary>
+    /// Time in milliseconds to warm up the camera after initialization.
+    /// During warmup, frames are read and discarded to allow auto-exposure to settle.
+    /// Set to 0 to disable warmup. Default is 500ms.
+    /// </summary>
+    public int InitializationWarmupMs { get; set; } = 500;
 }

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -61,7 +61,8 @@ switch (cameraProvider.ToLowerInvariant())
             FlipVertical = builder.Configuration.GetValue<bool?>("Camera:FlipVertical") ?? false,
             JpegQuality = builder.Configuration.GetValue<int?>("Camera:JpegQuality") ?? 90,
             PreferredWidth = builder.Configuration.GetValue<int?>("Camera:PreferredWidth") ?? 1920,
-            PreferredHeight = builder.Configuration.GetValue<int?>("Camera:PreferredHeight") ?? 1080
+            PreferredHeight = builder.Configuration.GetValue<int?>("Camera:PreferredHeight") ?? 1080,
+            InitializationWarmupMs = builder.Configuration.GetValue<int?>("Camera:InitializationWarmupMs") ?? 500
         };
         builder.Services.AddSingleton<ICameraProvider>(sp =>
         {

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -18,7 +18,8 @@
     "FlipVertical": false,
     "JpegQuality": 90,
     "PreferredWidth": 1920,
-    "PreferredHeight": 1080
+    "PreferredHeight": 1080,
+    "InitializationWarmupMs": 500
   },
   "Capture": {
     "CountdownDurationMs": 3000


### PR DESCRIPTION
## Summary

- Adds configurable `InitializationWarmupMs` setting (default: 500ms) to allow camera auto-exposure to settle before first capture
- During warmup, frames are actively read and discarded, feeding the auto-exposure algorithm real scene data
- Fixes the issue where the first photo was darker because the camera hadn't had time to adjust after initialization

Closes #12

## Test plan

- [x] Build and run the application
- [x] Take several photos in sequence
- [x] Verify first photo has similar brightness to subsequent photos
- [x] Check logs for warmup message: "Camera warmup complete: X frames in 500ms"
- [x] Optionally test with different `InitializationWarmupMs` values (0 to disable, higher values for slow cameras)

🤖 Generated with [Claude Code](https://claude.com/claude-code)