### PR TITLE
Fix release workflow to upload binaries to existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version number (e.g., 1.0.0)"
-        required: true
-        type: string
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -50,11 +43,9 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          fi
+          VERSION="${{ github.event.release.tag_name }}"
+          # Strip leading 'v' if present
+          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Publish for Windows x64
         run: |
@@ -71,12 +62,9 @@ jobs:
           cd publish/win-x64
           zip -r ../../PhotoBooth-${{ steps.version.outputs.version }}-win-x64.zip .
 
-      - name: Create GitHub Release
+      - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
-          name: Photo Booth v${{ steps.version.outputs.version }}
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
-          draft: ${{ github.event_name == 'workflow_dispatch' }}
-          generate_release_notes: true
+          tag_name: ${{ github.event.release.tag_name }}
           files: |
             PhotoBooth-${{ steps.version.outputs.version }}-win-x64.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,13 @@ Example configuration:
 GitHub Actions workflows in `.github/workflows/`:
 
 - **ci.yml**: Runs on PRs and pushes to main. Builds .NET and frontend, runs tests, and lints.
-- **release.yml**: Creates releases. Triggered by version tags (`v*`) or manual dispatch. Publishes self-contained Windows x64 executable.
+- **release.yml**: Triggered when a release is published via the GitHub UI. Builds and uploads the Windows x64 executable to the release.
 
 ### Creating a Release
 
-1. Tag a version: `git tag v1.0.0 && git push origin v1.0.0`
-2. The release workflow will automatically build and create a GitHub release with the Windows executable.
-
-Or trigger manually from the Actions tab with a version number.
+1. Create a release in the GitHub UI (with tag like `v1.0.0`)
+2. The release workflow automatically triggers on publish
+3. The Windows executable is built and uploaded to the release as an asset
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Change workflow trigger from tag push/manual dispatch to `release: published` event
- Extract version from `github.event.release.tag_name` instead of git ref
- Upload assets to the existing release instead of creating a new one

Closes #36

## Test plan
- [x] Create a new release in the GitHub UI (e.g., `v0.1.0`)
- [x] Verify the workflow triggers on publish
- [x] Verify the zip file appears as a release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)