### PR TITLE
Add swirl-in effect for slideshow transitions

### DIFF
--- a/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
+++ b/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
@@ -1,3 +1,3 @@
 namespace PhotoBooth.Application.DTOs;
 
-public record ClientConfigDto(string? QrCodeBaseUrl);
+public record ClientConfigDto(string? QrCodeBaseUrl, bool SwirlEffect);

--- a/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
@@ -13,7 +13,8 @@ public static class ConfigEndpoints
     private static IResult GetConfig(IConfiguration configuration)
     {
         var qrCodeBaseUrl = configuration.GetValue<string>("QrCode:BaseUrl");
-        var config = new ClientConfigDto(qrCodeBaseUrl);
+        var swirlEffect = configuration.GetValue<bool>("Slideshow:SwirlEffect", true);
+        var config = new ClientConfigDto(qrCodeBaseUrl, swirlEffect);
         return Results.Ok(config);
     }
 }

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -38,5 +38,8 @@
   },
   "QrCode": {
     "BaseUrl": ""
+  },
+  "Slideshow": {
+    "SwirlEffect": true
   }
 }

--- a/src/PhotoBooth.Server/wwwroot/index.html
+++ b/src/PhotoBooth.Server/wwwroot/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>photobooth-web</title>
-    <script type="module" crossorigin src="/assets/index-FDUby-re.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BIlwubHz.css">
+    <script type="module" crossorigin src="/assets/index-4yRq4GfC.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-PMLpvV4T.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -51,10 +51,14 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Swirl effect animations */
+.photo-display.swirl {
   animation: swirl-in 0.8s ease-out forwards;
 }
 
-.photo-display.fading-out {
+.photo-display.swirl.fading-out {
   animation: swirl-out 0.5s ease-in forwards;
 }
 
@@ -78,6 +82,25 @@ body {
     opacity: 0;
     transform: scale(0.3) rotate(180deg);
   }
+}
+
+/* Fade effect animations */
+.photo-display.fade {
+  animation: fade-in 0.5s ease-out forwards;
+}
+
+.photo-display.fade.fading-out {
+  animation: fade-out 0.5s ease-out forwards;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 .photo-image {

--- a/src/PhotoBooth.Web/src/App.tsx
+++ b/src/PhotoBooth.Web/src/App.tsx
@@ -20,6 +20,7 @@ function getRouteFromHash(): Route {
 function App() {
   const [route, setRoute] = useState<Route>(getRouteFromHash);
   const [qrCodeBaseUrl, setQrCodeBaseUrl] = useState<string | undefined>(undefined);
+  const [swirlEffect, setSwirlEffect] = useState(true);
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -36,6 +37,7 @@ function App() {
         if (config.qrCodeBaseUrl) {
           setQrCodeBaseUrl(config.qrCodeBaseUrl);
         }
+        setSwirlEffect(config.swirlEffect);
       })
       .catch(err => {
         console.error('Failed to load client config:', err);
@@ -44,7 +46,7 @@ function App() {
 
   return (
     <div className="app">
-      {route.type === 'booth' && <BoothPage qrCodeBaseUrl={qrCodeBaseUrl} />}
+      {route.type === 'booth' && <BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} />}
       {route.type === 'download' && <DownloadPage />}
       {route.type === 'photo' && <PhotoDetailPage code={route.code} />}
     </div>

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -59,4 +59,5 @@ export interface QueuedPhoto {
 
 export interface ClientConfigDto {
   qrCodeBaseUrl: string | null;
+  swirlEffect: boolean;
 }

--- a/src/PhotoBooth.Web/src/components/PhotoDisplay.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoDisplay.tsx
@@ -19,10 +19,11 @@ interface PhotoDisplayProps {
   showQrCode?: boolean;
   qrCodeBaseUrl?: string;
   kenBurns?: KenBurnsConfig;
+  swirlEffect?: boolean;
   fadingOut?: boolean;
 }
 
-export function PhotoDisplay({ photoId, code, showCode = true, showQrCode = true, qrCodeBaseUrl, kenBurns, fadingOut = false }: PhotoDisplayProps) {
+export function PhotoDisplay({ photoId, code, showCode = true, showQrCode = true, qrCodeBaseUrl, kenBurns, swirlEffect = true, fadingOut = false }: PhotoDisplayProps) {
   const imageUrl = getPhotoImageUrl(photoId);
   const baseUrl = qrCodeBaseUrl || window.location.origin;
 
@@ -36,7 +37,11 @@ export function PhotoDisplay({ photoId, code, showCode = true, showQrCode = true
     '--kb-duration': kenBurns.duration,
   } as CSSProperties : undefined;
 
-  const displayClassName = fadingOut ? 'photo-display fading-out' : 'photo-display';
+  const displayClassName = [
+    'photo-display',
+    swirlEffect ? 'swirl' : 'fade',
+    fadingOut ? 'fading-out' : '',
+  ].filter(Boolean).join(' ');
 
   return (
     <div className={displayClassName}>

--- a/src/PhotoBooth.Web/src/components/Slideshow.tsx
+++ b/src/PhotoBooth.Web/src/components/Slideshow.tsx
@@ -9,6 +9,7 @@ interface SlideshowProps {
   intervalMs?: number;
   paused?: boolean;
   qrCodeBaseUrl?: string;
+  swirlEffect?: boolean;
 }
 
 function randomInRange(min: number, max: number): number {
@@ -69,9 +70,9 @@ interface PhotoState {
   key: number;
 }
 
-const FADE_DURATION_MS = 800;
+const FADE_DURATION_MS = 500;
 
-export function Slideshow({ intervalMs = 8000, paused = false, qrCodeBaseUrl }: SlideshowProps) {
+export function Slideshow({ intervalMs = 8000, paused = false, qrCodeBaseUrl, swirlEffect = true }: SlideshowProps) {
   const { t } = useTranslation();
   const [currentState, setCurrentState] = useState<PhotoState | null>(null);
   const [previousState, setPreviousState] = useState<PhotoState | null>(null);
@@ -131,6 +132,7 @@ export function Slideshow({ intervalMs = 8000, paused = false, qrCodeBaseUrl }: 
           code={previousState.photo.code}
           kenBurns={previousState.kenBurns}
           qrCodeBaseUrl={qrCodeBaseUrl}
+          swirlEffect={swirlEffect}
           fadingOut
         />
       )}
@@ -140,6 +142,7 @@ export function Slideshow({ intervalMs = 8000, paused = false, qrCodeBaseUrl }: 
         code={currentState.photo.code}
         kenBurns={currentState.kenBurns}
         qrCodeBaseUrl={qrCodeBaseUrl}
+        swirlEffect={swirlEffect}
       />
     </div>
   );

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -13,6 +13,7 @@ const WATCHDOG_RELOAD_MS = 5 * 60 * 1000;
 
 interface BoothPageProps {
   qrCodeBaseUrl?: string;
+  swirlEffect?: boolean;
 }
 
 function randomInRange(min: number, max: number): number {
@@ -67,7 +68,7 @@ interface DisplayPhoto {
   fromQueue: boolean; // true if from queue, false if newly captured
 }
 
-export function BoothPage({ qrCodeBaseUrl }: BoothPageProps) {
+export function BoothPage({ qrCodeBaseUrl, swirlEffect = true }: BoothPageProps) {
   // Queue of interrupted photos waiting to be displayed (FIFO)
   const [photoQueue, setPhotoQueue] = useState<QueuedPhoto[]>([]);
   // Currently displaying photo
@@ -272,7 +273,7 @@ export function BoothPage({ qrCodeBaseUrl }: BoothPageProps) {
   return (
     <div className="booth-page" onClick={handleTrigger}>
       {/* Show slideshow when not showing captured photos */}
-      {showSlideshow && <Slideshow paused={showCountdown} qrCodeBaseUrl={qrCodeBaseUrl} />}
+      {showSlideshow && <Slideshow paused={showCountdown} qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} />}
 
       {/* Show captured photo with same Ken Burns effect as slideshow */}
       {showCapturedPhoto && (
@@ -284,6 +285,7 @@ export function BoothPage({ qrCodeBaseUrl }: BoothPageProps) {
               code={previousDisplay.photo.code}
               kenBurns={previousDisplay.kenBurns}
               qrCodeBaseUrl={qrCodeBaseUrl}
+              swirlEffect={swirlEffect}
               fadingOut
             />
           )}
@@ -293,6 +295,7 @@ export function BoothPage({ qrCodeBaseUrl }: BoothPageProps) {
             code={currentDisplay.photo.code}
             kenBurns={currentDisplay.kenBurns}
             qrCodeBaseUrl={qrCodeBaseUrl}
+            swirlEffect={swirlEffect}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replace simple fade-in/out animations with swirl effects that rotate and scale photos
- Photos now spin in from -180° at 30% scale, creating a more dynamic visual effect
- Matching swirl-out animation rotates photos away when transitioning
- Add `Slideshow:SwirlEffect` setting to enable/disable the effect (defaults to `true`)

When disabled, the slideshow reverts to the original fade transition.

**Configuration:**
```json
{
  "Slideshow": {
    "SwirlEffect": true
  }
}
```

Closes #37

## Test plan
- [ ] Run `pnpm run dev` in `src/PhotoBooth.Web/`
- [ ] Open http://localhost:5173 and navigate to the booth page
- [ ] Observe photos swirling in with rotation effect
- [ ] Verify smooth transition between photos
- [ ] Ensure Ken Burns effect still works during display
- [ ] Set `Slideshow:SwirlEffect` to `false` and verify fade effect is used instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)