### PR TITLE
Replace custom hash routing with React Router

### DIFF
--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -153,6 +153,9 @@ app.MapCameraEndpoints();
 app.MapEventsEndpoints();
 app.MapConfigEndpoints(builder.Configuration);
 
+// SPA fallback for client-side routing
+app.MapFallbackToFile("index.html");
+
 app.Run();
 
 // Make the implicit Program class public for testing

--- a/src/PhotoBooth.Server/wwwroot/index.html
+++ b/src/PhotoBooth.Server/wwwroot/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>photobooth-web</title>
-    <script type="module" crossorigin src="/assets/index-4yRq4GfC.js"></script>
+    <script type="module" crossorigin src="/assets/index-CutnAwJj.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-PMLpvV4T.css">
   </head>
   <body>

--- a/src/PhotoBooth.Web/package.json
+++ b/src/PhotoBooth.Web/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-qr-code": "^2.0.18"
+    "react-qr-code": "^2.0.18",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/PhotoBooth.Web/pnpm-lock.yaml
+++ b/src/PhotoBooth.Web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-qr-code:
         specifier: ^2.0.18
         version: 2.0.18(react@19.2.3)
+      react-router-dom:
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -663,6 +666,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -980,6 +987,23 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.13.0:
+    resolution: {integrity: sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.13.0:
+    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -1004,6 +1028,9 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1672,6 +1699,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1987,6 +2016,20 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-router-dom@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-router: 7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+
+  react-router@7.13.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.3
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+
   react@19.2.3: {}
 
   resolve-from@4.0.0: {}
@@ -2027,6 +2070,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/PhotoBooth.Web/src/App.tsx
+++ b/src/PhotoBooth.Web/src/App.tsx
@@ -1,35 +1,14 @@
 import { useState, useEffect } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { BoothPage } from './pages/BoothPage';
 import { DownloadPage } from './pages/DownloadPage';
 import { PhotoDetailPage } from './pages/PhotoDetailPage';
 import { getClientConfig } from './api/client';
 import './App.css';
 
-type Route = { type: 'booth' } | { type: 'download' } | { type: 'photo'; code: string };
-
-function getRouteFromHash(): Route {
-  const hash = window.location.hash.slice(1);
-  if (hash.startsWith('download')) return { type: 'download' };
-  if (hash.startsWith('photo/')) {
-    const code = hash.slice('photo/'.length);
-    return { type: 'photo', code };
-  }
-  return { type: 'booth' };
-}
-
 function App() {
-  const [route, setRoute] = useState<Route>(getRouteFromHash);
   const [qrCodeBaseUrl, setQrCodeBaseUrl] = useState<string | undefined>(undefined);
   const [swirlEffect, setSwirlEffect] = useState(true);
-
-  useEffect(() => {
-    const handleHashChange = () => {
-      setRoute(getRouteFromHash());
-    };
-
-    window.addEventListener('hashchange', handleHashChange);
-    return () => window.removeEventListener('hashchange', handleHashChange);
-  }, []);
 
   useEffect(() => {
     getClientConfig()
@@ -45,11 +24,15 @@ function App() {
   }, []);
 
   return (
-    <div className="app">
-      {route.type === 'booth' && <BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} />}
-      {route.type === 'download' && <DownloadPage />}
-      {route.type === 'photo' && <PhotoDetailPage code={route.code} />}
-    </div>
+    <BrowserRouter>
+      <div className="app">
+        <Routes>
+          <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} />} />
+          <Route path="/download" element={<DownloadPage />} />
+          <Route path="/photo/:code" element={<PhotoDetailPage />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
   );
 }
 

--- a/src/PhotoBooth.Web/src/components/QRCodeOverlay.tsx
+++ b/src/PhotoBooth.Web/src/components/QRCodeOverlay.tsx
@@ -6,7 +6,7 @@ interface QRCodeOverlayProps {
 }
 
 export function QRCodeOverlay({ code, baseUrl }: QRCodeOverlayProps) {
-  const downloadUrl = `${baseUrl}/#download?code=${code}`;
+  const downloadUrl = `${baseUrl}/download?code=${code}`;
 
   return (
     <div className="qr-code-container">

--- a/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
@@ -1,20 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getPhotoByCode, getPhotoImageUrl } from '../api/client';
 import type { PhotoDto } from '../api/types';
 import { PhotoGrid } from '../components/PhotoGrid';
 import { useTranslation } from '../i18n/useTranslation';
 
-function getCodeFromHash(): string | null {
-  const hash = window.location.hash;
-  const queryStart = hash.indexOf('?');
-  if (queryStart === -1) return null;
-
-  const queryString = hash.slice(queryStart + 1);
-  const params = new URLSearchParams(queryString);
-  return params.get('code');
-}
-
 export function DownloadPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { t, language, setLanguage } = useTranslation();
   const [code, setCode] = useState('');
   const [photo, setPhoto] = useState<PhotoDto | null>(null);
@@ -44,12 +37,12 @@ export function DownloadPage() {
   }, [t]);
 
   useEffect(() => {
-    const codeFromUrl = getCodeFromHash();
+    const codeFromUrl = searchParams.get('code');
     if (codeFromUrl) {
       setCode(codeFromUrl);
       fetchPhoto(codeFromUrl);
     }
-  }, [fetchPhoto]);
+  }, [searchParams, fetchPhoto]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,7 +61,7 @@ export function DownloadPage() {
   };
 
   const handlePhotoClick = (photoCode: string) => {
-    window.location.hash = `#photo/${photoCode}`;
+    navigate(`/photo/${photoCode}`);
   };
 
   const handleBackToSearch = () => {

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -1,19 +1,20 @@
 import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { getPhotoByCode, getPhotoImageUrl } from '../api/client';
 import type { PhotoDto } from '../api/types';
 import { useTranslation } from '../i18n/useTranslation';
 
-interface PhotoDetailPageProps {
-  code: string;
-}
-
-export function PhotoDetailPage({ code }: PhotoDetailPageProps) {
+export function PhotoDetailPage() {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const [photo, setPhoto] = useState<PhotoDto | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(!!code);
+  const [error, setError] = useState<string | null>(code ? null : t('photoNotFoundError'));
 
   useEffect(() => {
+    if (!code) return;
+
     getPhotoByCode(code)
       .then(result => {
         if (result) {
@@ -38,7 +39,7 @@ export function PhotoDetailPage({ code }: PhotoDetailPageProps) {
   };
 
   const handleBack = () => {
-    window.location.hash = '#download';
+    navigate('/download');
   };
 
   if (loading) {


### PR DESCRIPTION
## Summary

- Replace custom `window.location.hash` routing with React Router using `BrowserRouter`
- Enable clean URLs (`/download` instead of `/#download`)
- Add SPA fallback in backend so direct URL access works

## Changes

- **App.tsx**: Use `BrowserRouter`, `Routes`, and `Route` components
- **PhotoDetailPage.tsx**: Use `useParams()` and `useNavigate()` hooks
- **DownloadPage.tsx**: Use `useSearchParams()` and `useNavigate()` hooks
- **QRCodeOverlay.tsx**: Generate clean URLs for QR codes
- **Program.cs**: Add `MapFallbackToFile("index.html")` for SPA routing

## Test plan

- [ ] `/` shows booth page
- [ ] `/download` shows download page
- [ ] `/download?code=123` auto-fills code
- [ ] `/photo/ABC` shows photo detail
- [ ] Browser back/forward works
- [ ] Page refresh maintains route
- [ ] QR code generates correct URL

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)