### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/magnusakselvoll/photo-booth-take-two/security/code-scanning/1](https://github.com/magnusakselvoll/photo-booth-take-two/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal permissions needed. Since this CI workflow only checks out code and runs local build/test/lint commands, it should require only read access to repository contents.

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root level (just under `name:` and before `on:`). This block will apply to all jobs that do not override permissions. For this workflow, `contents: read` is sufficient, matching the typical recommendation for pure CI workflows. No other jobs or steps need to be modified, and no additional imports or external definitions are required.

Concretely: edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

between lines 1 and 3 (after `name: CI` and the blank line, before `on:`). This will explicitly limit the `GITHUB_TOKEN` to read-only repository contents for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
