### PR TITLE
Add security vulnerability disclosure policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Instructions for Claude Code when working on this repository.
 
+## Issue Tracking
+
+Issues are tracked in GitHub. Use `gh issue list` to see open issues and `gh issue view <number>` for details.
+
 ## Git Workflow (GitHub Flow)
 
 Always use GitHub Flow when working on issues:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it using [GitHub Security Advisories](https://github.com/magnusakselvoll/photo-booth-take-two/security/advisories/new). This allows for private discussion of the issue before public disclosure.
+
+For non-sensitive security issues (e.g., hardening suggestions, missing headers), feel free to open a regular [GitHub issue](https://github.com/magnusakselvoll/photo-booth-take-two/issues).
+
+## What to Expect
+
+- **Acknowledgment**: Within 7 days of your report.
+- **Resolution timeline**: This is a volunteer-maintained project, so fixes may take time. Critical vulnerabilities will be prioritized.
+- **Public disclosure**: After a fix is released, the advisory will be made public. If a fix is not feasible within 90 days, the advisory may be disclosed publicly to inform users.
+
+## Scope
+
+This policy applies to the code in this repository. Third-party dependencies are out of scope, but reports about vulnerable dependencies are welcome.
+
+## Supported Versions
+
+Only the latest release is supported with security updates.


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with vulnerability disclosure policy using GitHub Security Advisories
- Add issue tracking section to `CLAUDE.md` pointing to GitHub Issues

Closes #7

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Verify the Security Advisories link works
- [ ] Verify the Issues link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)