### PR TITLE
Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `ci.yml` to follow the principle of least privilege
- `release.yml` already had `permissions: contents: write` — no change needed

Closes #47

## Test plan

- [ ] Verify CI workflow still passes on this PR
- [ ] Confirm the code scanning alert is resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)