### PR TITLE
Enhance Android camera reliability with retry and recovery

### DIFF
--- a/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
@@ -73,4 +73,10 @@ public class AndroidCameraOptions
     /// re-verified (wake, unlock, open camera) before the next capture.
     /// </summary>
     public int CameraOpenTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Maximum number of capture retries after a failure. On retry, the provider
+    /// performs full device recovery (wake, unlock, open camera) before re-attempting.
+    /// </summary>
+    public int MaxCaptureRetries { get; set; } = 1;
 }

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -68,7 +68,9 @@ switch (cameraProvider.ToLowerInvariant())
             CaptureTimeoutMs = builder.Configuration.GetValue<int?>("Camera:CaptureTimeoutMs") ?? 15000,
             FileStabilityDelayMs = builder.Configuration.GetValue<int?>("Camera:FileStabilityDelayMs") ?? 200,
             CapturePollingIntervalMs = builder.Configuration.GetValue<int?>("Camera:CapturePollingIntervalMs") ?? 500,
-            AdbCommandTimeoutMs = builder.Configuration.GetValue<int?>("Camera:AdbCommandTimeoutMs") ?? 10000
+            AdbCommandTimeoutMs = builder.Configuration.GetValue<int?>("Camera:AdbCommandTimeoutMs") ?? 10000,
+            CameraOpenTimeoutSeconds = builder.Configuration.GetValue<int?>("Camera:CameraOpenTimeoutSeconds") ?? 30,
+            MaxCaptureRetries = builder.Configuration.GetValue<int?>("Camera:MaxCaptureRetries") ?? 1
         };
         builder.Services.AddSingleton<ICameraProvider>(sp =>
         {


### PR DESCRIPTION
## Summary
- Add capture retry with automatic device recovery (wake, unlock, reopen camera) when capture fails — configurable via `MaxCaptureRetries` (default 1)
- Focus keepalive now detects device lock/disconnect every other tick and flags recovery needed via `_needsRecovery` flag
- Fix workflow hard timeout: derive from camera latency (45s buffer for Android) instead of fixed 12s that was shorter than the 15s capture timeout
- Wire `CameraOpenTimeoutSeconds` and `MaxCaptureRetries` to configuration in Program.cs

## Test plan
- [x] New test: first capture attempt fails, retry succeeds after recovery
- [x] New test: all capture attempts fail, throws exception
- [x] New test: device locked between captures triggers full setup
- [x] All 99 existing + new tests pass
- [x] Manual testing with Android phone: close camera app → trigger capture → should recover and succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)