### PR TITLE
Fix CI hanging by excluding hardware-dependent tests and parallelize jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
+  dotnet:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +21,21 @@ jobs:
         with:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"
+
+      - name: Restore .NET dependencies
+        run: dotnet restore
+
+      - name: Build .NET
+        run: dotnet build --no-restore
+
+      - name: Test .NET
+        run: dotnet test --no-build --verbosity normal --filter "TestCategory!=Integration"
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -33,15 +48,6 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: src/PhotoBooth.Web/pnpm-lock.yaml
-
-      - name: Restore .NET dependencies
-        run: dotnet restore
-
-      - name: Build .NET
-        run: dotnet build --no-restore
-
-      - name: Test .NET
-        run: dotnet test --no-build --verbosity normal
 
       - name: Install frontend dependencies
         working-directory: src/PhotoBooth.Web

--- a/tests/PhotoBooth.Infrastructure.Tests/OpenCvCaptureTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/OpenCvCaptureTests.cs
@@ -4,6 +4,7 @@ using PhotoBooth.Infrastructure.Camera;
 namespace PhotoBooth.Infrastructure.Tests;
 
 [TestClass]
+[TestCategory("Integration")]
 public class OpenCvCaptureTests
 {
     private ILogger<OpenCvCameraProvider> _logger = null!;


### PR DESCRIPTION
## Summary
- Mark `OpenCvCaptureTests` with `[TestCategory("Integration")]` and exclude them from CI with `--filter "TestCategory!=Integration"` — these tests require a physical camera and can hang indefinitely on Ubuntu runners
- Split the single `build-and-test` job into parallel `dotnet` and `frontend` jobs for faster wall-clock time
- Cancelled stuck run 21997415578

Closes #62

## Test plan
- [x] `dotnet test --filter "TestCategory!=Integration"` passes locally (54 tests)
- [x] `dotnet test --filter "TestCategory=Integration" --list-tests` shows only the 5 OpenCV tests
- [ ] CI completes without hanging on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)