### PR TITLE
Reorganize settings with provider subsections and configurable values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Avoid: niche libraries, multiple libraries solving the same problem, dependencie
 
 ## Camera Provider Configuration
 
-The application supports camera providers configured via `Camera:Provider` in appsettings.json:
+The application supports camera providers configured via `Camera:Provider` in appsettings.json. Provider-specific settings are in subsections (`Camera:OpenCv`, `Camera:Android`), each with their own `CaptureLatencyMs`.
 
 | Provider | Value | Description |
 |----------|-------|-------------|
@@ -110,40 +110,48 @@ The application supports camera providers configured via `Camera:Provider` in ap
 | Mock | `"Mock"` | For testing without a camera. |
 
 Example OpenCV configuration:
-```json
+```jsonc
 {
   "Camera": {
     "Provider": "OpenCv",
-    "DeviceIndex": 0,
-    "CaptureLatencyMs": 100,
-    "FramesToSkip": 5,
-    "FlipVertical": false,
-    "JpegQuality": 90,
-    "PreferredWidth": 1920,
-    "PreferredHeight": 1080,
-    "InitializationWarmupMs": 500
+    "OpenCv": {
+      "CaptureLatencyMs": 100,
+      "DeviceIndex": 0,
+      "FramesToSkip": 5,
+      "FlipVertical": false,
+      "JpegQuality": 90,
+      "PreferredWidth": 1920,
+      "PreferredHeight": 1080,
+      "InitializationWarmupMs": 500,
+      "CaptureLockTimeoutSeconds": 5
+    }
   }
 }
 ```
 
 Example Android configuration:
-```json
+```jsonc
 {
   "Camera": {
     "Provider": "Android",
-    "AdbPath": "adb",
-    "DeviceImageFolder": "/sdcard/DCIM/Camera",
-    "PinCode": null,
-    "CameraAction": "STILL_IMAGE_CAMERA",
-    "FocusKeepaliveIntervalSeconds": 15,
-    "FocusKeepaliveMaxDurationSeconds": 180,
-    "DeleteAfterDownload": true,
-    "FileSelectionRegex": "^.*\\.jpg$",
-    "CaptureLatencyMs": 3000,
-    "CaptureTimeoutMs": 15000,
-    "FileStabilityDelayMs": 200,
-    "CapturePollingIntervalMs": 500,
-    "AdbCommandTimeoutMs": 10000
+    "Android": {
+      "CaptureLatencyMs": 100,
+      "AdbPath": "adb",
+      "DeviceImageFolder": "/sdcard/DCIM/Camera",
+      "PinCode": null,
+      "CameraAction": "STILL_IMAGE_CAMERA",
+      "FocusKeepaliveIntervalSeconds": 15,
+      "FocusKeepaliveMaxDurationSeconds": 180,
+      "DeleteAfterDownload": true,
+      "FileSelectionRegex": "^.*\\.jpg$",
+      "CaptureTimeoutMs": 15000,
+      "FileStabilityDelayMs": 200,
+      "CapturePollingIntervalMs": 500,
+      "AdbCommandTimeoutMs": 10000,
+      "CameraOpenTimeoutSeconds": 30,
+      "MaxCaptureRetries": 1,
+      "CaptureLockTimeoutSeconds": 5
+    }
   }
 }
 ```
@@ -152,10 +160,15 @@ Example Android configuration:
 
 | Key | Description | Default |
 |-----|-------------|---------|
+| `Capture:CountdownDurationMs` | Countdown duration in ms before photo is taken | `7000` |
+| `Capture:BufferTimeoutHighLatencyMs` | Hard timeout buffer for high-latency cameras | `45000` |
+| `Capture:BufferTimeoutLowLatencyMs` | Hard timeout buffer for low-latency cameras | `12000` |
 | `Slideshow:SwirlEffect` | Enable swirl animation effect on slideshow | `true` |
+| `Slideshow:IntervalMs` | Interval in ms between slideshow transitions | `30000` |
 | `Event:Name` | Event name (used as storage subfolder) | Current date |
 | `QrCode:BaseUrl` | Base URL for QR code links | Request origin |
-| `Capture:CountdownDurationMs` | Default countdown duration in ms | `3000` |
+| `RateLimiting:PermitLimit` | Max requests per rate limit window | `5` |
+| `RateLimiting:WindowSeconds` | Rate limit window duration in seconds | `10` |
 
 ## Security
 
@@ -173,7 +186,7 @@ No HSTS header — inappropriate for a local-network app with dynamic IPs.
 
 ### Rate Limiting
 
-The `/api/photos/capture` and `/api/photos/trigger` endpoints are rate-limited using ASP.NET Core's built-in rate limiter: 5 requests per 10-second fixed window. Returns HTTP 429 when exceeded.
+The `/api/photos/capture` and `/api/photos/trigger` endpoints are rate-limited using ASP.NET Core's built-in rate limiter. Defaults: 5 requests per 10-second fixed window (configurable via `RateLimiting:PermitLimit` and `RateLimiting:WindowSeconds`). Returns HTTP 429 when exceeded.
 
 ## CI/CD
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,10 +145,13 @@ Key configurable parameters:
 |---------|-------------|---------|
 | `PhotoStorage:Path` | Where photos are saved | OS-specific app data |
 | `Camera:Provider` | Camera provider to use | `OpenCv` |
-| `Capture:CountdownDurationMs` | Countdown duration in ms | `3000` |
+| `Capture:CountdownDurationMs` | Countdown duration in ms | `7000` |
 | `Slideshow:SwirlEffect` | Enable swirl effect on slideshow | `true` |
+| `Slideshow:IntervalMs` | Interval in ms between slideshow transitions | `30000` |
 | `Event:Name` | Event name (used for storage folder) | Current date |
 | `QrCode:BaseUrl` | Base URL for QR codes | Request origin |
+| `RateLimiting:PermitLimit` | Max requests per rate limit window | `5` |
+| `RateLimiting:WindowSeconds` | Rate limit window in seconds | `10` |
 
 ## Internationalization (i18n)
 

--- a/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
+++ b/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
@@ -1,3 +1,3 @@
 namespace PhotoBooth.Application.DTOs;
 
-public record ClientConfigDto(string? QrCodeBaseUrl, bool SwirlEffect);
+public record ClientConfigDto(string? QrCodeBaseUrl, bool SwirlEffect, int SlideshowIntervalMs);

--- a/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
@@ -52,7 +52,7 @@ public class AndroidCameraOptions
     /// triggering capture to when the photo is actually taken, used to adjust
     /// countdown timing so "0" aligns with the actual capture moment.
     /// </summary>
-    public int CaptureLatencyMs { get; set; } = 3000;
+    public int CaptureLatencyMs { get; set; } = 100;
 
     /// <summary>
     /// Maximum time in milliseconds to wait for a new photo to appear on the device.
@@ -86,4 +86,9 @@ public class AndroidCameraOptions
     /// performs full device recovery (wake, unlock, open camera) before re-attempting.
     /// </summary>
     public int MaxCaptureRetries { get; set; } = 1;
+
+    /// <summary>
+    /// Seconds to wait for the capture lock before reporting camera busy.
+    /// </summary>
+    public int CaptureLockTimeoutSeconds { get; set; } = 5;
 }

--- a/src/PhotoBooth.Infrastructure/Camera/AndroidCameraProvider.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/AndroidCameraProvider.cs
@@ -88,7 +88,7 @@ public class AndroidCameraProvider : ICameraProvider, IDisposable
 
         _logger.LogInformation("Starting Android camera capture");
 
-        if (!await _captureLock.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken))
+        if (!await _captureLock.WaitAsync(TimeSpan.FromSeconds(_options.CaptureLockTimeoutSeconds), cancellationToken))
         {
             throw new CameraNotAvailableException("Camera is busy");
         }

--- a/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraOptions.cs
@@ -49,4 +49,9 @@ public class OpenCvCameraOptions
     /// Set to 0 to disable warmup. Default is 500ms.
     /// </summary>
     public int InitializationWarmupMs { get; set; } = 500;
+
+    /// <summary>
+    /// Seconds to wait for the capture lock before reporting camera busy.
+    /// </summary>
+    public int CaptureLockTimeoutSeconds { get; set; } = 5;
 }

--- a/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraProvider.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/OpenCvCameraProvider.cs
@@ -138,7 +138,7 @@ public class OpenCvCameraProvider : ICameraProvider, IDisposable
 
         _logger.LogInformation("Starting OpenCV camera capture from device {DeviceIndex}", _options.DeviceIndex);
 
-        if (!await _captureLock.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken))
+        if (!await _captureLock.WaitAsync(TimeSpan.FromSeconds(_options.CaptureLockTimeoutSeconds), cancellationToken))
         {
             throw new CameraNotAvailableException("Camera is busy");
         }

--- a/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
@@ -14,7 +14,8 @@ public static class ConfigEndpoints
     {
         var qrCodeBaseUrl = configuration.GetValue<string>("QrCode:BaseUrl");
         var swirlEffect = configuration.GetValue<bool>("Slideshow:SwirlEffect", true);
-        var config = new ClientConfigDto(qrCodeBaseUrl, swirlEffect);
+        var slideshowIntervalMs = configuration.GetValue<int?>("Slideshow:IntervalMs") ?? 30000;
+        var config = new ClientConfigDto(qrCodeBaseUrl, swirlEffect, slideshowIntervalMs);
         return Results.Ok(config);
     }
 }

--- a/src/PhotoBooth.Server/appsettings.Development.json
+++ b/src/PhotoBooth.Server/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -1,4 +1,5 @@
 {
+  // Logging configuration
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -10,37 +11,111 @@
     }
   },
   "AllowedHosts": "*",
+
+  // Camera configuration
   "Camera": {
-    "Provider": "Android",
-    "PinCode": "1111",
-    "DeviceIndex": 0,
-    "CaptureLatencyMs": 100,
-    "FramesToSkip": 5,
-    "FlipVertical": false,
-    "JpegQuality": 90,
-    "PreferredWidth": 1920,
-    "PreferredHeight": 1080,
-    "InitializationWarmupMs": 500
+    // Provider: "OpenCv", "Android", or "Mock"
+    "Provider": "OpenCv",
+
+    // OpenCV-specific settings (only used when Provider is "OpenCv")
+    "OpenCv": {
+      // Latency compensation in ms (time between trigger and actual capture)
+      "CaptureLatencyMs": 100,
+      "DeviceIndex": 0,
+      "FramesToSkip": 5,
+      "FlipVertical": false,
+      "JpegQuality": 90,
+      "PreferredWidth": 1920,
+      "PreferredHeight": 1080,
+      "InitializationWarmupMs": 500,
+      // Seconds to wait for the capture lock before reporting camera busy
+      "CaptureLockTimeoutSeconds": 5
+    },
+
+    // Android-specific settings (only used when Provider is "Android")
+    "Android": {
+      // Latency compensation in ms (time between trigger and actual capture)
+      "CaptureLatencyMs": 100,
+      "AdbPath": "adb",
+      "DeviceImageFolder": "/sdcard/DCIM/Camera",
+      // PIN code to unlock device screen (null if no PIN)
+      "PinCode": "1111",
+      // Camera intent action
+      "CameraAction": "STILL_IMAGE_CAMERA",
+      // Interval in seconds between periodic focus keepalive commands
+      "FocusKeepaliveIntervalSeconds": 15,
+      // Max duration in seconds for focus keepalive (0 = indefinite)
+      "FocusKeepaliveMaxDurationSeconds": 180,
+      // Whether to delete photos from device after downloading
+      "DeleteAfterDownload": true,
+      // Regex to match photo files on device
+      "FileSelectionRegex": "^.*\\.jpg$",
+      // Maximum time in ms to wait for a new photo to appear
+      "CaptureTimeoutMs": 15000,
+      // Delay in ms between file stability checks
+      "FileStabilityDelayMs": 200,
+      // Polling interval in ms when waiting for a new photo
+      "CapturePollingIntervalMs": 500,
+      // Timeout in ms for individual ADB commands
+      "AdbCommandTimeoutMs": 10000,
+      // Seconds after which the camera is considered stale and must be reopened
+      "CameraOpenTimeoutSeconds": 30,
+      // Maximum number of capture retries after failure
+      "MaxCaptureRetries": 1,
+      // Seconds to wait for the capture lock before reporting camera busy
+      "CaptureLockTimeoutSeconds": 5
+    }
   },
+
+  // Capture workflow settings
   "Capture": {
-    "CountdownDurationMs": 3000
+    // Countdown duration in ms before photo is taken
+    "CountdownDurationMs": 7000,
+    // Hard timeout buffer in ms for high-latency cameras (e.g. Android over ADB)
+    "BufferTimeoutHighLatencyMs": 45000,
+    // Hard timeout buffer in ms for low-latency cameras (e.g. OpenCV)
+    "BufferTimeoutLowLatencyMs": 12000
   },
+
+  // Keyboard/GPIO input settings
   "Input": {
     "EnableKeyboard": false
   },
+
+  // Photo storage path (empty = default AppData location)
   "PhotoStorage": {
     "Path": ""
   },
+
+  // Trigger endpoint security
   "Trigger": {
     "RestrictToLocalhost": true
   },
+
+  // Network security (blocks outbound HTTP requests)
   "NetworkSecurity": {
     "BlockOutboundRequests": true
   },
+
+  // QR code settings
   "QrCode": {
+    // Base URL for QR code links (empty = use request origin)
     "BaseUrl": ""
   },
+
+  // Slideshow settings
   "Slideshow": {
-    "SwirlEffect": true
+    // Enable swirl animation effect on slideshow transitions
+    "SwirlEffect": true,
+    // Interval in ms between slideshow photo transitions
+    "IntervalMs": 30000
+  },
+
+  // Rate limiting for capture/trigger endpoints
+  "RateLimiting": {
+    // Maximum requests per window
+    "PermitLimit": 5,
+    // Fixed window duration in seconds
+    "WindowSeconds": 10
   }
 }

--- a/src/PhotoBooth.Web/src/App.tsx
+++ b/src/PhotoBooth.Web/src/App.tsx
@@ -9,6 +9,7 @@ import './App.css';
 function App() {
   const [qrCodeBaseUrl, setQrCodeBaseUrl] = useState<string | undefined>(undefined);
   const [swirlEffect, setSwirlEffect] = useState(true);
+  const [slideshowIntervalMs, setSlideshowIntervalMs] = useState(30000);
 
   useEffect(() => {
     getClientConfig()
@@ -17,6 +18,7 @@ function App() {
           setQrCodeBaseUrl(config.qrCodeBaseUrl);
         }
         setSwirlEffect(config.swirlEffect);
+        setSlideshowIntervalMs(config.slideshowIntervalMs);
       })
       .catch(err => {
         console.error('Failed to load client config:', err);
@@ -27,7 +29,7 @@ function App() {
     <BrowserRouter>
       <div className="app">
         <Routes>
-          <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} />} />
+          <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} slideshowIntervalMs={slideshowIntervalMs} />} />
           <Route path="/download" element={<DownloadPage />} />
           <Route path="/photo/:code" element={<PhotoDetailPage />} />
         </Routes>

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -60,4 +60,5 @@ export interface QueuedPhoto {
 export interface ClientConfigDto {
   qrCodeBaseUrl: string | null;
   swirlEffect: boolean;
+  slideshowIntervalMs: number;
 }

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -8,7 +8,7 @@ import { useSlideshowNavigation } from '../hooks/useSlideshowNavigation';
 import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 import type { PhotoBoothEvent, QueuedPhoto } from '../api/types';
 
-const PREVIEW_DURATION_MS = 8000; // Same as slideshow interval
+const DEFAULT_SLIDESHOW_INTERVAL_MS = 30000;
 const ERROR_DISPLAY_MS = 3000;
 const FADE_DURATION_MS = 500;
 const WATCHDOG_RELOAD_MS = 5 * 60 * 1000;
@@ -16,6 +16,7 @@ const WATCHDOG_RELOAD_MS = 5 * 60 * 1000;
 interface BoothPageProps {
   qrCodeBaseUrl?: string;
   swirlEffect?: boolean;
+  slideshowIntervalMs?: number;
 }
 
 function randomInRange(min: number, max: number): number {
@@ -70,7 +71,7 @@ interface DisplayPhoto {
   fromQueue: boolean; // true if from queue, false if newly captured
 }
 
-export function BoothPage({ qrCodeBaseUrl, swirlEffect = true }: BoothPageProps) {
+export function BoothPage({ qrCodeBaseUrl, swirlEffect = true, slideshowIntervalMs = DEFAULT_SLIDESHOW_INTERVAL_MS }: BoothPageProps) {
   // Queue of interrupted photos waiting to be displayed
   const [photoQueue, setPhotoQueue] = useState<QueuedPhoto[]>([]);
   // Current index within the queue
@@ -108,7 +109,7 @@ export function BoothPage({ qrCodeBaseUrl, swirlEffect = true }: BoothPageProps)
     toggleMode,
     refresh: refreshSlideshow,
   } = useSlideshowNavigation({
-    intervalMs: PREVIEW_DURATION_MS,
+    intervalMs: slideshowIntervalMs,
     paused: slideshowPaused,
   });
 
@@ -183,8 +184,8 @@ export function BoothPage({ qrCodeBaseUrl, swirlEffect = true }: BoothPageProps)
 
       // Refresh slideshow to include the newly captured photo
       refreshSlideshow();
-    }, PREVIEW_DURATION_MS);
-  }, [refreshSlideshow]);
+    }, slideshowIntervalMs);
+  }, [refreshSlideshow, slideshowIntervalMs]);
 
   // Show next photo from queue
   const showNextFromQueue = useCallback(() => {

--- a/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
@@ -56,7 +56,7 @@ public sealed class CaptureWorkflowServiceTests
         await _service.TriggerCaptureAsync("test");
 
         // Wait for the background workflow to complete
-        await Task.Delay(500);
+        await Task.Delay(1000);
 
         // Assert - should have countdown event and photo captured event
         Assert.IsGreaterThanOrEqualTo(_eventBroadcaster.BroadcastedEvents.Count, 2);
@@ -75,7 +75,7 @@ public sealed class CaptureWorkflowServiceTests
         await _service.TriggerCaptureAsync("test");
 
         // Wait for the background workflow to complete
-        await Task.Delay(500);
+        await Task.Delay(1000);
 
         // Assert - should have countdown event and capture failed event
         Assert.IsGreaterThanOrEqualTo(_eventBroadcaster.BroadcastedEvents.Count, 2);


### PR DESCRIPTION
## Summary
- Restructure `appsettings.json` with descriptive comments and provider-specific camera subsections (`Camera:OpenCv`, `Camera:Android`)
- Extract hardcoded values to config: buffer timeouts, capture lock timeout, rate limiting, slideshow interval
- Update defaults: countdown 7s, slideshow interval 30s, Android capture latency 100ms (warmup now in PrepareAsync)
- Add 500ms "smile delay" so photo is captured during "Smile" phase, not at the countdown transition
- Serve slideshow interval from server config to frontend instead of hardcoding
- Delete redundant `appsettings.Development.json`

Closes #66

## Test plan
- [x] `dotnet build` — all projects compile
- [x] `dotnet test` — all 102 tests pass
- [x] `pnpm run build` — frontend builds clean
- [ ] Verify countdown timing feels right with the smile delay
- [ ] Verify slideshow interval change (30s) works in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)