### PR TITLE
Restore default appsettings.json automatically when missing

### DIFF
--- a/src/PhotoBooth.Server/DefaultSettingsRestorer.cs
+++ b/src/PhotoBooth.Server/DefaultSettingsRestorer.cs
@@ -1,0 +1,27 @@
+using System.Reflection;
+
+namespace PhotoBooth.Server;
+
+public static class DefaultSettingsRestorer
+{
+    private const string EmbeddedResourceName = "appsettings.default.json";
+
+    public static void EnsureSettingsExist(string directory, Assembly? assembly = null)
+    {
+        var settingsPath = Path.Combine(directory, "appsettings.json");
+
+        if (File.Exists(settingsPath))
+            return;
+
+        assembly ??= Assembly.GetExecutingAssembly();
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{EmbeddedResourceName}' not found in assembly '{assembly.FullName}'.");
+
+        using var fileStream = File.Create(settingsPath);
+        stream.CopyTo(fileStream);
+
+        Serilog.Log.Information("Restored default appsettings.json to {Path}", settingsPath);
+    }
+}

--- a/src/PhotoBooth.Server/PhotoBooth.Server.csproj
+++ b/src/PhotoBooth.Server/PhotoBooth.Server.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <EmbeddedResource Include="appsettings.json" LogicalName="appsettings.default.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Swashbuckle.AspNetCore" />

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -11,6 +11,7 @@ using PhotoBooth.Infrastructure.Network;
 using PhotoBooth.Infrastructure.Storage;
 using PhotoBooth.Server.Endpoints;
 using PhotoBooth.Server.Filters;
+using PhotoBooth.Server;
 using PhotoBooth.Server.Middleware;
 using Serilog;
 
@@ -18,6 +19,8 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .WriteTo.File("logs/photobooth.log", rollingInterval: RollingInterval.Day)
     .CreateLogger();
+
+DefaultSettingsRestorer.EnsureSettingsExist(AppContext.BaseDirectory);
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseSerilog();

--- a/tests/PhotoBooth.Server.Tests/DefaultSettingsRestorerTests.cs
+++ b/tests/PhotoBooth.Server.Tests/DefaultSettingsRestorerTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using PhotoBooth.Server;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public class DefaultSettingsRestorerTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void EnsureSettingsExist_WritesFile_WhenMissing()
+    {
+        var assembly = Assembly.GetAssembly(typeof(DefaultSettingsRestorer))!;
+
+        DefaultSettingsRestorer.EnsureSettingsExist(_tempDir, assembly);
+
+        var settingsPath = Path.Combine(_tempDir, "appsettings.json");
+        Assert.IsTrue(File.Exists(settingsPath));
+
+        var content = File.ReadAllText(settingsPath);
+        Assert.Contains("Logging", content);
+    }
+
+    [TestMethod]
+    public void EnsureSettingsExist_DoesNotOverwrite_WhenFileExists()
+    {
+        var settingsPath = Path.Combine(_tempDir, "appsettings.json");
+        var customContent = "{ \"custom\": true }";
+        File.WriteAllText(settingsPath, customContent);
+
+        var assembly = Assembly.GetAssembly(typeof(DefaultSettingsRestorer))!;
+
+        DefaultSettingsRestorer.EnsureSettingsExist(_tempDir, assembly);
+
+        var content = File.ReadAllText(settingsPath);
+        Assert.AreEqual(customContent, content);
+    }
+}


### PR DESCRIPTION
## Summary
- Embeds `appsettings.json` as an assembly resource at build time
- On startup, if `appsettings.json` is missing from the output directory, it is restored from the embedded default
- Extracts restoration logic into a testable `DefaultSettingsRestorer` helper class

Closes #67

## Test plan
- [x] Unit test: file is written when missing
- [x] Unit test: existing file is not overwritten
- [x] Manual: publish the app, delete `appsettings.json` from the publish directory, restart — file should be restored with defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)