### PR TITLE
Fix release binary name stripping leading dots from version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,10 @@ jobs:
         id: version
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          # Strip leading 'v' if present
-          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+          # Strip leading 'v' and any leading dots (e.g. v.0.0.1 -> 0.0.1)
+          VERSION="${VERSION#v}"
+          VERSION="${VERSION#.}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Publish for Windows x64
         run: |


### PR DESCRIPTION
The v.0.0.1 release produced "PhotoBooth-.0.0.1-win-x64.zip" because the version step only stripped the leading 'v', leaving the errant dot. Now also strips a leading dot after removing the 'v' prefix.

Closes #70

https://claude.ai/code/session_01MnFef4bZXVoUoptnWT4wx7

## Summary
<!-- Brief description of changes -->

## Related Issue
Closes #

## Checklist
- [ ] Tests pass (`dotnet test`)
- [ ] Documentation updated (if applicable):
  - [ ] SPEC.md (requirements/behavior changes)
  - [ ] README.md (setup/config/user-facing changes)
  - [ ] CLAUDE.md (technical/architecture changes)
