### PR TITLE
Fix QR code URL to use /photo/{code} and strip trailing slash

### DIFF
--- a/src/PhotoBooth.Web/src/components/QRCodeOverlay.tsx
+++ b/src/PhotoBooth.Web/src/components/QRCodeOverlay.tsx
@@ -6,7 +6,7 @@ interface QRCodeOverlayProps {
 }
 
 export function QRCodeOverlay({ code, baseUrl }: QRCodeOverlayProps) {
-  const downloadUrl = `${baseUrl}/download?code=${code}`;
+  const downloadUrl = `${baseUrl.replace(/\/$/, '')}/photo/${code}`;
 
   return (
     <div className="qr-code-container">


### PR DESCRIPTION
## Summary

- Changes QR code URL from `/download?code={code}` to `/photo/{code}` to match the gallery's canonical photo URL
- Strips any trailing slash from `QrCode:BaseUrl` to prevent double-slash URLs (e.g. `http://host:5000//photo/1`)
- Adds unit tests that mock `react-qr-code` to verify the encoded URL format

Closes #90