### PR TITLE
feat: pre-generate resized images after capture and on startup

### DIFF
--- a/src/PhotoBooth.Application/Services/IImageResizer.cs
+++ b/src/PhotoBooth.Application/Services/IImageResizer.cs
@@ -15,4 +15,12 @@ public interface IImageResizer
     }
 
     Task<byte[]?> GetResizedImageAsync(Guid photoId, int width, CancellationToken ct);
+
+    async Task PreGenerateAllSizesAsync(Guid photoId, CancellationToken ct)
+    {
+        foreach (var width in AllowedWidths)
+        {
+            await GetResizedImageAsync(photoId, width, ct);
+        }
+    }
 }

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -120,9 +120,13 @@ builder.Services.AddSingleton<ICaptureWorkflowService>(sp =>
     var captureService = sp.GetRequiredService<IPhotoCaptureService>();
     var cameraProvider = sp.GetRequiredService<ICameraProvider>();
     var eventBroadcaster = sp.GetRequiredService<IEventBroadcaster>();
+    var imageResizer = sp.GetRequiredService<IImageResizer>();
     var logger = sp.GetRequiredService<ILogger<CaptureWorkflowService>>();
-    return new CaptureWorkflowService(captureService, cameraProvider, eventBroadcaster, logger, countdownDurationMs, bufferTimeoutHighLatencyMs, bufferTimeoutLowLatencyMs);
+    return new CaptureWorkflowService(captureService, cameraProvider, eventBroadcaster, imageResizer, logger, countdownDurationMs, bufferTimeoutHighLatencyMs, bufferTimeoutLowLatencyMs);
 });
+
+// Register thumbnail warmup service
+builder.Services.AddHostedService<ThumbnailWarmupService>();
 
 // Register input providers and manager
 var enableKeyboardInput = builder.Configuration.GetValue<bool>("Input:EnableKeyboard");

--- a/src/PhotoBooth.Server/ThumbnailWarmupService.cs
+++ b/src/PhotoBooth.Server/ThumbnailWarmupService.cs
@@ -1,0 +1,52 @@
+using PhotoBooth.Application.Services;
+using PhotoBooth.Domain.Interfaces;
+
+namespace PhotoBooth.Server;
+
+public class ThumbnailWarmupService(
+    IPhotoRepository photoRepository,
+    IImageResizer imageResizer,
+    ILogger<ThumbnailWarmupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var photos = await photoRepository.GetAllAsync(stoppingToken);
+
+            if (photos.Count == 0)
+            {
+                logger.LogInformation("Thumbnail warmup: no photos to pre-generate");
+                return;
+            }
+
+            logger.LogInformation("Thumbnail warmup: pre-generating thumbnails for {Count} photos", photos.Count);
+
+            for (var i = 0; i < photos.Count; i++)
+            {
+                stoppingToken.ThrowIfCancellationRequested();
+
+                var photo = photos[i];
+                try
+                {
+                    await imageResizer.PreGenerateAllSizesAsync(photo.Id, stoppingToken);
+                    logger.LogInformation("Thumbnail warmup: pre-generated thumbnails for photo {Current}/{Total}", i + 1, photos.Count);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Thumbnail warmup: failed to pre-generate thumbnails for photo {PhotoId}", photo.Id);
+                }
+            }
+
+            logger.LogInformation("Thumbnail warmup: completed");
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Thumbnail warmup: cancelled");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Thumbnail warmup: unexpected error");
+        }
+    }
+}

--- a/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
@@ -12,6 +12,7 @@ public sealed class CaptureWorkflowServiceTests
     private StubPhotoCaptureService _captureService = null!;
     private StubCameraProvider _cameraProvider = null!;
     private StubEventBroadcaster _eventBroadcaster = null!;
+    private StubImageResizer _imageResizer = null!;
     private CaptureWorkflowService _service = null!;
 
     [TestInitialize]
@@ -20,11 +21,13 @@ public sealed class CaptureWorkflowServiceTests
         _captureService = new StubPhotoCaptureService();
         _cameraProvider = new StubCameraProvider();
         _eventBroadcaster = new StubEventBroadcaster();
+        _imageResizer = new StubImageResizer();
 
         _service = new CaptureWorkflowService(
             _captureService,
             _cameraProvider,
             _eventBroadcaster,
+            _imageResizer,
             NullLogger<CaptureWorkflowService>.Instance,
             countdownDurationMs: 100); // Short countdown for tests
     }

--- a/tests/PhotoBooth.Application.Tests/TestDoubles/StubImageResizer.cs
+++ b/tests/PhotoBooth.Application.Tests/TestDoubles/StubImageResizer.cs
@@ -1,0 +1,9 @@
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Application.Tests.TestDoubles;
+
+public sealed class StubImageResizer : IImageResizer
+{
+    public Task<byte[]?> GetResizedImageAsync(Guid photoId, int width, CancellationToken ct)
+        => Task.FromResult<byte[]?>(null);
+}


### PR DESCRIPTION
## Summary

- Add `PreGenerateAllSizesAsync` default method to `IImageResizer` that iterates all 5 allowed widths
- Fire-and-forget thumbnail pre-generation in `CaptureWorkflowService` immediately after each photo capture
- Add `ThumbnailWarmupService` hosted service that pre-generates thumbnails for all existing photos on startup (sequential to avoid disk I/O overload)

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — all 119 tests pass
- [ ] Manual: capture a photo, verify all 5 sizes appear in `.thumbnails/` immediately
- [ ] Manual: start server with existing photos but empty `.thumbnails/`, verify warmup logs pre-generation progress on startup

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)