### PR TITLE
feat: redirect non-localhost users from / to /download

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Example Android configuration:
 | `RateLimiting:PermitLimit` | Max requests per rate limit window | `5` |
 | `RateLimiting:WindowSeconds` | Rate limit window duration in seconds | `10` |
 | `Thumbnails:JpegQuality` | JPEG quality (0-100) for server-side resized thumbnails | `80` |
+| `Booth:RestrictToLocalhost` | Redirect non-localhost users from `/` to `/download` | `true` |
 
 ## Security
 

--- a/src/PhotoBooth.Server/Middleware/BoothRedirectExtensions.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothRedirectExtensions.cs
@@ -1,0 +1,9 @@
+namespace PhotoBooth.Server.Middleware;
+
+public static class BoothRedirectExtensions
+{
+    public static IApplicationBuilder UseBoothRedirect(this IApplicationBuilder app, bool enabled)
+    {
+        return app.UseMiddleware<BoothRedirectMiddleware>(enabled);
+    }
+}

--- a/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
@@ -1,0 +1,53 @@
+using System.Net;
+
+namespace PhotoBooth.Server.Middleware;
+
+public sealed class BoothRedirectMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly bool _enabled;
+
+    public BoothRedirectMiddleware(RequestDelegate next, bool enabled)
+    {
+        _next = next;
+        _enabled = enabled;
+    }
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        if (_enabled && IsRootPath(context.Request.Path) && !IsLocalhost(context.Connection.RemoteIpAddress))
+        {
+            context.Response.Redirect("/download", permanent: false);
+            return Task.CompletedTask;
+        }
+
+        return _next(context);
+    }
+
+    private static bool IsRootPath(PathString path)
+    {
+        return !path.HasValue || path == "/";
+    }
+
+    private static bool IsLocalhost(IPAddress? ipAddress)
+    {
+        if (ipAddress is null)
+        {
+            return false;
+        }
+
+        // Check for IPv4 loopback (127.0.0.1) or IPv6 loopback (::1)
+        if (IPAddress.IsLoopback(ipAddress))
+        {
+            return true;
+        }
+
+        // Check for IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)
+        if (ipAddress.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(ipAddress.MapToIPv4()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -178,6 +178,10 @@ else
 // Security headers (before static files so headers apply to all responses)
 app.UseSecurityHeaders();
 
+// Redirect non-localhost users from / to /download (gallery)
+var restrictBoothToLocalhost = builder.Configuration.GetValue<bool?>("Booth:RestrictToLocalhost") ?? true;
+app.UseBoothRedirect(restrictBoothToLocalhost);
+
 // Rate limiting
 app.UseRateLimiter();
 

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -115,6 +115,11 @@
     "Path": ""
   },
 
+  // Booth page security (redirects non-localhost users from / to /download)
+  "Booth": {
+    "RestrictToLocalhost": true
+  },
+
   // Trigger endpoint security
   "Trigger": {
     "RestrictToLocalhost": true

--- a/tests/PhotoBooth.Server.Tests/BoothRedirectMiddlewareTests.cs
+++ b/tests/PhotoBooth.Server.Tests/BoothRedirectMiddlewareTests.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using PhotoBooth.Server.Middleware;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public sealed class BoothRedirectMiddlewareTests
+{
+    [TestMethod]
+    public async Task InvokeAsync_WhenDisabled_PassesThroughForNonLocalhostRoot()
+    {
+        // Arrange
+        var middleware = new BoothRedirectMiddleware(enabled: false, next: _ => Task.CompletedTask);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.AreNotEqual(StatusCodes.Status302Found, context.Response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_RedirectsNonLocalhostFromRoot()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called for non-localhost root request");
+        Assert.AreEqual(StatusCodes.Status302Found, context.Response.StatusCode);
+        Assert.AreEqual("/download", context.Response.Headers.Location.ToString());
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughIPv4Localhost()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Loopback, "/"); // 127.0.0.1
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv4 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughIPv6Localhost()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.IPv6Loopback, "/"); // ::1
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv6 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughIPv4MappedLoopback()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Loopback.MapToIPv6(), "/"); // ::ffff:127.0.0.1
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for IPv4-mapped IPv6 localhost");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughNonLocalhostOnNonRootPath()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/download");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for non-root path");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughNonLocalhostOnApiPath()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/api/photos");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsTrue(nextCalled, "Next delegate should be called for API path");
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_RedirectsNullIpFromRoot()
+    {
+        // Arrange
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(null, "/");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called when IP is null (fail-secure)");
+        Assert.AreEqual(StatusCodes.Status302Found, context.Response.StatusCode);
+    }
+
+    private static HttpContext CreateContext(IPAddress? remoteIp, string path)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = remoteIp;
+        httpContext.Request.Path = path;
+        return httpContext;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BoothRedirectMiddleware` that intercepts requests to `/` from non-localhost IPs and returns a 302 redirect to `/download` (the gallery)
- Registered in the pipeline between `UseSecurityHeaders()` and `UseRateLimiter()`
- Configurable via `Booth:RestrictToLocalhost` (defaults to `true`)
- 8 unit tests covering all cases: disabled, IPv4/IPv6/mapped localhost pass-through, non-root pass-through, external IP redirect, null IP fail-secure

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — 127/127 tests passed
- [ ] Manual: access `http://localhost/` → booth page loads
- [ ] Manual: access `http://<local-ip>/` → redirects to `/download`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #93