### PR TITLE
feat: show waiting message while developing photo after capture

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -177,6 +177,19 @@ body {
   letter-spacing: -0.02em;
 }
 
+.waiting-message {
+  font-size: 5rem;
+  font-weight: 500;
+  color: #fff;
+  text-shadow: 0 0 40px rgba(255, 255, 255, 0.5);
+  animation: waiting-pulse 2s ease-in-out infinite;
+}
+
+@keyframes waiting-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 /* Preview */
 .preview {
   width: 100%;

--- a/src/PhotoBooth.Web/src/components/CaptureOverlay.tsx
+++ b/src/PhotoBooth.Web/src/components/CaptureOverlay.tsx
@@ -7,6 +7,7 @@ interface CaptureOverlayProps {
 
 export function CaptureOverlay({ durationMs, onComplete }: CaptureOverlayProps) {
   const [secondsRemaining, setSecondsRemaining] = useState(Math.ceil(durationMs / 1000));
+  const [waitingForCapture, setWaitingForCapture] = useState(false);
 
   useEffect(() => {
     if (secondsRemaining <= 0) {
@@ -21,9 +22,25 @@ export function CaptureOverlay({ durationMs, onComplete }: CaptureOverlayProps) 
     return () => clearTimeout(timer);
   }, [secondsRemaining, onComplete]);
 
+  useEffect(() => {
+    if (secondsRemaining > 0) return;
+
+    const timer = setTimeout(() => {
+      setWaitingForCapture(true);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [secondsRemaining]);
+
   return (
     <div className="capture-overlay">
-      <div className="countdown">{secondsRemaining > 0 ? secondsRemaining : 'Smile!'}</div>
+      {secondsRemaining > 0 ? (
+        <div className="countdown">{secondsRemaining}</div>
+      ) : !waitingForCapture ? (
+        <div className="countdown">Smile!</div>
+      ) : (
+        <div className="waiting-message">Developing photo...</div>
+      )}
     </div>
   );
 }

--- a/src/PhotoBooth.Web/src/components/__tests__/CaptureOverlay.test.tsx
+++ b/src/PhotoBooth.Web/src/components/__tests__/CaptureOverlay.test.tsx
@@ -40,4 +40,26 @@ describe('CaptureOverlay', () => {
 
     expect(onComplete).toHaveBeenCalledOnce();
   });
+
+  it('shows "Smile!" immediately after countdown completes', () => {
+    render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(1000); });
+
+    expect(screen.getByText('Smile!')).toBeInTheDocument();
+  });
+
+  it('shows waiting message after countdown completes and 500ms elapses', () => {
+    render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
+
+    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(1000); });
+    act(() => { vi.advanceTimersByTime(500); });
+
+    expect(screen.getByText('Developing photo...')).toBeInTheDocument();
+    expect(screen.queryByText('Smile!')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- After the countdown ends and "Smile!" has shown for 500ms, transitions to a pulsing "Developing photo..." message
- Gives users visual feedback that the system is working during high-latency captures (e.g. Android camera over ADB)
- Frontend-only change — no backend modifications needed

## Test plan

- [ ] `pnpm test` in `src/PhotoBooth.Web` — all 92 tests pass
- [ ] `pnpm run build` in `src/PhotoBooth.Web` — no build errors
- [ ] Manual: trigger capture → countdown → "Smile!" → after 500ms → "Developing photo..." pulsing → photo displays on capture

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)