### PR TITLE
feat: randomize capture overlay text with fun multilingual phrases

### DIFF
--- a/src/PhotoBooth.Web/src/components/CaptureOverlay.tsx
+++ b/src/PhotoBooth.Web/src/components/CaptureOverlay.tsx
@@ -1,4 +1,68 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+
+const SMILE_PHRASES = [
+  'Smile!',
+  'Cheese!',
+  'Say cheese!',
+  'Sonrie!',
+  'Looking good!',
+  'Guapo!',
+  'Guapa!',
+  'Gorgeous!',
+  'Diga whisky!',
+  'Fabulous!',
+  'Say aah!',
+  'Que guapo!',
+  'Que guapa!',
+  'Hermoso!',
+  'Hermosa!',
+  'You look amazing!',
+  'Stunning!',
+  'Selfie time!',
+  'Work it!',
+  'Fierce!',
+  'Ole!',
+  'Bellisimo!',
+  'Bellisima!',
+  'Say "yeah!"',
+  'Dazzling!',
+  'Preciosa!',
+  'Precioso!',
+  'Vogue!',
+  'Slay!',
+  'Yes queen!',
+  'Strike a pose!',
+  'Wow!',
+];
+
+const DEVELOPING_PHRASES = [
+  'Developing photo...',
+  'Working some magic...',
+  'Creando magia...',
+  'Almost there...',
+  'Un momento...',
+  'Patience, beauties...',
+  'Creating a masterpiece...',
+  'Uno momento, por favor...',
+  'Good things take time...',
+  'Casi listo...',
+  'Making you look fabulous...',
+  'Hold that pose...',
+];
+
+const COUNTDOWN_SUBSTITUTIONS: Record<number, readonly [string, string, string]> = {
+  1: ['one', 'uno', '📷'],
+  2: ['two', 'dos', '⭐'],
+  3: ['three', 'tres', '✨'],
+  4: ['four', 'cuatro', '🔥'],
+  5: ['five', 'cinco', '🎉'],
+  6: ['six', 'seis', '✌️'],
+  7: ['seven', 'siete', '😎'],
+};
+
+function pickRandom<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
 
 interface CaptureOverlayProps {
   durationMs: number;
@@ -8,6 +72,23 @@ interface CaptureOverlayProps {
 export function CaptureOverlay({ durationMs, onComplete }: CaptureOverlayProps) {
   const [secondsRemaining, setSecondsRemaining] = useState(Math.ceil(durationMs / 1000));
   const [waitingForCapture, setWaitingForCapture] = useState(false);
+
+  const smilePhrase = useMemo(() => pickRandom(SMILE_PHRASES), []);
+  const developingPhrase = useMemo(() => pickRandom(DEVELOPING_PHRASES), []);
+
+  const countdownDisplays = useMemo(() => {
+    const maxSeconds = Math.ceil(durationMs / 1000);
+    const displays: Record<number, string> = {};
+    for (let s = 1; s <= maxSeconds; s++) {
+      const subs = COUNTDOWN_SUBSTITUTIONS[s];
+      if (subs && Math.random() < 0.15) {
+        displays[s] = pickRandom(subs);
+      } else {
+        displays[s] = String(s);
+      }
+    }
+    return displays;
+  }, [durationMs]);
 
   useEffect(() => {
     if (secondsRemaining <= 0) {
@@ -35,11 +116,11 @@ export function CaptureOverlay({ durationMs, onComplete }: CaptureOverlayProps) 
   return (
     <div className="capture-overlay">
       {secondsRemaining > 0 ? (
-        <div className="countdown">{secondsRemaining}</div>
+        <div className="countdown">{countdownDisplays[secondsRemaining] ?? String(secondsRemaining)}</div>
       ) : !waitingForCapture ? (
-        <div className="countdown">Smile!</div>
+        <div className="countdown">{smilePhrase}</div>
       ) : (
-        <div className="waiting-message">Developing photo...</div>
+        <div className="waiting-message">{developingPhrase}</div>
       )}
     </div>
   );

--- a/src/PhotoBooth.Web/src/components/__tests__/CaptureOverlay.test.tsx
+++ b/src/PhotoBooth.Web/src/components/__tests__/CaptureOverlay.test.tsx
@@ -5,11 +5,14 @@ import { CaptureOverlay } from '../CaptureOverlay';
 describe('CaptureOverlay', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // Return > 0.15 so countdown numbers are never substituted
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('renders countdown number', () => {
@@ -41,25 +44,26 @@ describe('CaptureOverlay', () => {
     expect(onComplete).toHaveBeenCalledOnce();
   });
 
-  it('shows "Smile!" immediately after countdown completes', () => {
-    render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
+  it('shows smile phrase immediately after countdown completes', () => {
+    const { container } = render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
 
     act(() => { vi.advanceTimersByTime(1000); });
     act(() => { vi.advanceTimersByTime(1000); });
     act(() => { vi.advanceTimersByTime(1000); });
 
-    expect(screen.getByText('Smile!')).toBeInTheDocument();
+    expect(container.querySelector('.countdown')).toBeInTheDocument();
+    expect(container.querySelector('.waiting-message')).not.toBeInTheDocument();
   });
 
   it('shows waiting message after countdown completes and 500ms elapses', () => {
-    render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
+    const { container } = render(<CaptureOverlay durationMs={3000} onComplete={vi.fn()} />);
 
     act(() => { vi.advanceTimersByTime(1000); });
     act(() => { vi.advanceTimersByTime(1000); });
     act(() => { vi.advanceTimersByTime(1000); });
     act(() => { vi.advanceTimersByTime(500); });
 
-    expect(screen.getByText('Developing photo...')).toBeInTheDocument();
-    expect(screen.queryByText('Smile!')).not.toBeInTheDocument();
+    expect(container.querySelector('.waiting-message')).toBeInTheDocument();
+    expect(container.querySelector('.countdown')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Add 32 randomized smile prompts (English, Spanish, and fun phrases like "Slay!", "Vogue!", "Ole!")
- Add 12 randomized developing messages (e.g. "Creando magia...", "Patience, beauties...", "Casi listo...")
- Each countdown number (1–7) has a ~15% chance of being replaced by its English word, Spanish word, or a fun emoji

Selections are picked randomly each capture session via `useMemo`, so they stay stable within a session but vary across captures.

## Test plan

- [ ] Build passes: `pnpm run build`
- [ ] All 92 tests pass: `pnpm test`
- [ ] Trigger several captures and observe varied smile phrases and developing messages
- [ ] Occasionally observe a countdown digit replaced by a word or emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #100