### PR TITLE
Visual overhaul of gallery pages

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -218,177 +218,100 @@ body {
 
 /* Download Page */
 .download-page {
-  min-height: 100vh;
-  padding: 2rem;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  background: #111;
+  background: #000;
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
-.download-page h1 {
-  margin-bottom: 2rem;
-  font-size: 2rem;
-}
-
-.code-form {
+/* Search Bar */
+.search-bar {
   display: flex;
-  gap: 1rem;
-  margin-bottom: 2rem;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #000;
+  padding: 0.625rem 0.75rem;
+  gap: 0;
 }
 
 .code-input {
-  font-size: 1.5rem;
-  padding: 0.75rem 1rem;
-  border: 2px solid #333;
-  border-radius: 0.5rem;
-  background: #222;
+  flex: 1;
+  font-size: 1rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #333;
+  border-right: none;
+  border-radius: 0.5rem 0 0 0.5rem;
+  background: #1a1a1a;
   color: #fff;
-  text-align: center;
-  font-family: monospace;
-  width: 200px;
+  font-family: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.code-input::placeholder {
+  color: #666;
 }
 
 .code-input:focus {
   outline: none;
-  border-color: #3b82f6;
 }
 
-.submit-button,
-.download-button,
-.share-button {
-  font-size: 1.25rem;
-  padding: 0.75rem 1.5rem;
-  border: none;
-  border-radius: 0.5rem;
-  background: #3b82f6;
+.search-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #333;
+  border-left: none;
+  border-radius: 0 0.5rem 0.5rem 0;
+  background: #1a1a1a;
   color: #fff;
   cursor: pointer;
-  transition: background 0.2s;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.submit-button:hover:not(:disabled),
-.download-button:hover,
-.share-button:hover {
-  background: #2563eb;
-}
-
-.submit-button:disabled {
-  background: #374151;
+.search-button:disabled {
+  color: #444;
   cursor: not-allowed;
 }
 
-.photo-result {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
+.search-button:focus {
+  outline: none;
 }
 
-.photo-preview {
-  max-width: 100%;
-  max-height: 60vh;
-  border-radius: 0.5rem;
-}
-
-.download-button,
-.share-button {
-  font-size: 1.5rem;
-  padding: 1rem 2rem;
-}
-
-.photo-result-actions {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.back-button {
-  font-size: 1.25rem;
-  padding: 0.75rem 1.5rem;
-  border: 2px solid #3b82f6;
-  border-radius: 0.5rem;
-  background: transparent;
-  color: #3b82f6;
-  cursor: pointer;
-  transition: background 0.2s, color 0.2s;
-}
-
-.back-button:hover {
-  background: #3b82f6;
-  color: #fff;
-}
-
-/* Divider */
-.divider {
-  width: 100%;
-  max-width: 600px;
-  display: flex;
-  align-items: center;
-  margin: 2rem 0;
-  color: #666;
-}
-
-.divider::before,
-.divider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: #333;
-}
-
-.divider span {
-  padding: 0 1rem;
-  font-size: 0.9rem;
+.search-button:not(:disabled):active {
+  background: #2a2a2a;
 }
 
 /* Photo Grid */
 .photo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
-  width: 100%;
-  max-width: 1200px;
-}
-
-@media (max-width: 500px) {
-  .photo-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: #000;
+  flex: 1;
 }
 
 .photo-grid-item {
-  position: relative;
-  aspect-ratio: 4/3;
-  border-radius: 0.5rem;
+  aspect-ratio: 1/1;
   overflow: hidden;
   cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.photo-grid-item:hover {
-  transform: scale(1.02);
-  box-shadow: 0 4px 20px rgba(59, 130, 246, 0.3);
+.photo-grid-item:active {
+  opacity: 0.8;
 }
 
 .photo-grid-item img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.photo-grid-code {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: rgba(0, 0, 0, 0.7);
-  color: #fff;
-  font-family: monospace;
-  font-size: 1.25rem;
-  padding: 0.5rem;
-  text-align: center;
+  display: block;
 }
 
 .photo-grid-loading,
@@ -398,6 +321,7 @@ body {
   font-size: 1.25rem;
   text-align: center;
   padding: 2rem;
+  grid-column: 1 / -1;
 }
 
 .photo-grid-error {
@@ -406,47 +330,99 @@ body {
 
 /* Photo Detail Page */
 .photo-detail-page {
-  min-height: 100vh;
-  padding: 2rem;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  background: #111;
+  background: #000;
+  padding-top: env(safe-area-inset-top);
 }
 
-.photo-detail-header {
-  width: 100%;
-  max-width: 1000px;
+.photo-detail-nav {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-  gap: 1rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.nav-back-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: transparent;
+  color: #3b82f6;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav-back-button:active {
+  opacity: 0.6;
 }
 
 .photo-detail-code {
+  flex: 1;
+  text-align: center;
   font-family: monospace;
-  font-size: 1.5rem;
+  font-size: 1.125rem;
   color: #fff;
 }
 
+.nav-spacer {
+  width: 44px;
+}
+
 .photo-detail-content {
+  flex: 1;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  justify-content: center;
+  overflow: hidden;
 }
 
 .photo-detail-image {
   max-width: 100%;
-  max-height: 70vh;
-  border-radius: 0.5rem;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .photo-detail-loading {
   color: #666;
   font-size: 1.25rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photo-detail-actions {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1rem 1rem calc(1rem + env(safe-area-inset-bottom));
+}
+
+.action-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  border: none;
+  border-radius: 50%;
+  background: #1a1a1a;
+  color: #fff;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.action-button:focus,
+.nav-back-button:focus {
+  outline: none;
+}
+
+.action-button:active {
+  opacity: 0.7;
 }
 
 /* Gamepad Debug Overlay */
@@ -470,9 +446,11 @@ body {
 /* Language Footer */
 .language-footer {
   margin-top: auto;
-  padding-top: 2rem;
+  padding: 1rem;
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom));
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
 }
 
@@ -484,6 +462,7 @@ body {
   cursor: pointer;
   padding: 0.25rem 0.5rem;
   transition: color 0.2s;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .language-button:hover {

--- a/src/PhotoBooth.Web/src/components/Icons.tsx
+++ b/src/PhotoBooth.Web/src/components/Icons.tsx
@@ -1,0 +1,81 @@
+interface IconProps {
+  size?: number;
+  className?: string;
+}
+
+export function ChevronLeftIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="15 18 9 12 15 6" />
+    </svg>
+  );
+}
+
+export function DownloadIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+export function ShareIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="9 11 4 11 4 21 20 21 20 11 15 11" />
+      <line x1="12" y1="2" x2="12" y2="15" />
+      <polyline points="8 6 12 2 16 6" />
+    </svg>
+  );
+}
+
+export function SearchIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -45,7 +45,6 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
             alt={`Photo ${photo.code}`}
             loading="lazy"
           />
-          <div className="photo-grid-code">{photo.code}</div>
         </div>
       ))}
     </div>

--- a/src/PhotoBooth.Web/src/i18n/__tests__/useTranslation.test.ts
+++ b/src/PhotoBooth.Web/src/i18n/__tests__/useTranslation.test.ts
@@ -46,7 +46,7 @@ describe('useTranslation', () => {
   it('t() returns correct string for each key', () => {
     const { result } = renderHook(() => useTranslation());
 
-    expect(result.current.t('downloadYourPhoto')).toBe('Download Your Photo');
+    expect(result.current.t('enterPhotoCode')).toBe('Photo code');
     expect(result.current.t('searching')).toBe('Searching...');
     expect(result.current.t('tapToTakePhoto')).toBe('Tap anywhere to take a photo');
   });

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -1,15 +1,12 @@
 export const translations = {
   en: {
     // Download page
-    downloadYourPhoto: 'Download Your Photo',
-    enterPhotoCode: 'Enter your photo code',
+    enterPhotoCode: 'Photo code',
     searching: 'Searching...',
     findPhoto: 'Find Photo',
     photoNotFound: 'Photo not found. Please check your code.',
     downloadPhoto: 'Download Photo',
     sharePhoto: 'Share Photo',
-    backToSearch: 'Back to Search',
-    orBrowseAllPhotos: 'or browse all photos',
 
     // Photo grid
     loadingPhotos: 'Loading photos...',
@@ -20,7 +17,6 @@ export const translations = {
     loading: 'Loading...',
     photoNotFoundError: 'Photo not found',
     backToGallery: 'Back to Gallery',
-    code: 'Code',
 
     // Booth page
     tapToTakePhoto: 'Tap anywhere to take a photo',
@@ -30,15 +26,12 @@ export const translations = {
   },
   es: {
     // Download page
-    downloadYourPhoto: 'Descarga Tu Foto',
-    enterPhotoCode: 'Ingresa el código de tu foto',
+    enterPhotoCode: 'Código de foto',
     searching: 'Buscando...',
     findPhoto: 'Buscar Foto',
     photoNotFound: 'Foto no encontrada. Por favor verifica el código.',
     downloadPhoto: 'Descargar Foto',
     sharePhoto: 'Compartir Foto',
-    backToSearch: 'Volver a Buscar',
-    orBrowseAllPhotos: 'o explora todas las fotos',
 
     // Photo grid
     loadingPhotos: 'Cargando fotos...',
@@ -49,7 +42,6 @@ export const translations = {
     loading: 'Cargando...',
     photoNotFoundError: 'Foto no encontrada',
     backToGallery: 'Volver a la Galería',
-    code: 'Código',
 
     // Booth page
     tapToTakePhoto: 'Toca en cualquier lugar para tomar una foto',

--- a/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
@@ -1,93 +1,29 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import { getPhotoByCode, getPhotoImageUrl, sharePhoto } from '../api/client';
-import type { PhotoDto } from '../api/types';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { PhotoGrid } from '../components/PhotoGrid';
+import { SearchIcon } from '../components/Icons';
 import { useTranslation } from '../i18n/useTranslation';
 
 export function DownloadPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const { t, language, setLanguage } = useTranslation();
   const [code, setCode] = useState('');
-  const [photo, setPhoto] = useState<PhotoDto | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [canShare, setCanShare] = useState(false);
 
-  useEffect(() => {
-    if (navigator.canShare) {
-      const testFile = new File([''], 'test.jpg', { type: 'image/jpeg' });
-      setCanShare(navigator.canShare({ files: [testFile] }));
-    }
-  }, []);
-
-  const fetchPhoto = useCallback(async (photoCode: string) => {
-    if (!photoCode.trim()) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const result = await getPhotoByCode(photoCode.trim());
-      if (result) {
-        setPhoto(result);
-      } else {
-        setError(t('photoNotFound'));
-        setPhoto(null);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t('photoNotFound'));
-      setPhoto(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [t]);
-
-  useEffect(() => {
-    const codeFromUrl = searchParams.get('code');
-    if (codeFromUrl) {
-      setCode(codeFromUrl);
-      fetchPhoto(codeFromUrl);
-    }
-  }, [searchParams, fetchPhoto]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    await fetchPhoto(code);
-  };
-
-  const handleDownload = () => {
-    if (!photo) return;
-
-    const link = document.createElement('a');
-    link.href = getPhotoImageUrl(photo.id);
-    link.download = `photo-${photo.code}.jpg`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
-  const handleShare = async () => {
-    if (!photo) return;
-    await sharePhoto(photo.id, photo.code);
+    const trimmed = code.trim();
+    if (trimmed) {
+      navigate(`/photo/${trimmed}`);
+    }
   };
 
   const handlePhotoClick = (photoCode: string) => {
     navigate(`/photo/${photoCode}`);
   };
 
-  const handleBackToSearch = () => {
-    setPhoto(null);
-    setCode('');
-    setError(null);
-  };
-
   return (
     <div className="download-page">
-      <h1>{t('downloadYourPhoto')}</h1>
-
-      <form onSubmit={handleSubmit} className="code-form">
+      <form onSubmit={handleSubmit} className="search-bar">
         <input
           type="text"
           value={code}
@@ -95,42 +31,15 @@ export function DownloadPage() {
           placeholder={t('enterPhotoCode')}
           className="code-input"
           maxLength={10}
+          inputMode="numeric"
           autoFocus
         />
-        <button type="submit" disabled={loading || !code.trim()} className="submit-button">
-          {loading ? t('searching') : t('findPhoto')}
+        <button type="submit" disabled={!code.trim()} className="search-button" aria-label={t('findPhoto')}>
+          <SearchIcon size={20} />
         </button>
       </form>
 
-      {error && <div className="error-message">{error}</div>}
-
-      {photo && (
-        <div className="photo-result">
-          <img src={getPhotoImageUrl(photo.id, 800)} alt={`Photo ${photo.code}`} className="photo-preview" />
-          <div className="photo-result-actions">
-            <button onClick={handleDownload} className="download-button">
-              {t('downloadPhoto')}
-            </button>
-            {canShare && (
-              <button onClick={handleShare} className="share-button">
-                {t('sharePhoto')}
-              </button>
-            )}
-            <button onClick={handleBackToSearch} className="back-button">
-              {t('backToSearch')}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {!photo && (
-        <>
-          <div className="divider">
-            <span>{t('orBrowseAllPhotos')}</span>
-          </div>
-          <PhotoGrid onPhotoClick={handlePhotoClick} />
-        </>
-      )}
+      <PhotoGrid onPhotoClick={handlePhotoClick} />
 
       <footer className="language-footer">
         <button

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getPhotoByCode, getPhotoImageUrl, sharePhoto } from '../api/client';
 import type { PhotoDto } from '../api/types';
+import { ChevronLeftIcon, DownloadIcon, ShareIcon } from '../components/Icons';
 import { useTranslation } from '../i18n/useTranslation';
 
 export function PhotoDetailPage() {
@@ -48,9 +49,20 @@ export function PhotoDetailPage() {
     navigate('/download');
   };
 
+  const navBar = (
+    <div className="photo-detail-nav">
+      <button onClick={handleBack} className="nav-back-button" aria-label={t('backToGallery')}>
+        <ChevronLeftIcon size={28} />
+      </button>
+      <span className="photo-detail-code">{photo?.code ?? code}</span>
+      <div className="nav-spacer" />
+    </div>
+  );
+
   if (loading) {
     return (
       <div className="photo-detail-page">
+        {navBar}
         <div className="photo-detail-loading">{t('loading')}</div>
       </div>
     );
@@ -59,38 +71,31 @@ export function PhotoDetailPage() {
   if (error || !photo) {
     return (
       <div className="photo-detail-page">
+        {navBar}
         <div className="error-message">{error || t('photoNotFoundError')}</div>
-        <button onClick={handleBack} className="back-button">
-          {t('backToGallery')}
-        </button>
       </div>
     );
   }
 
   return (
     <div className="photo-detail-page">
-      <div className="photo-detail-header">
-        <button onClick={handleBack} className="back-button">
-          {t('backToGallery')}
-        </button>
-        <span className="photo-detail-code">{t('code')}: {photo.code}</span>
-      </div>
+      {navBar}
       <div className="photo-detail-content">
         <img
           src={getPhotoImageUrl(photo.id, 1200)}
           alt={`Photo ${photo.code}`}
           className="photo-detail-image"
         />
-        <div className="photo-result-actions">
-          <button onClick={handleDownload} className="download-button">
-            {t('downloadPhoto')}
+      </div>
+      <div className="photo-detail-actions">
+        <button onClick={handleDownload} className="action-button" aria-label={t('downloadPhoto')}>
+          <DownloadIcon size={24} />
+        </button>
+        {canShare && (
+          <button onClick={handleShare} className="action-button" aria-label={t('sharePhoto')}>
+            <ShareIcon size={24} />
           </button>
-          {canShare && (
-            <button onClick={handleShare} className="share-button">
-              {t('sharePhoto')}
-            </button>
-          )}
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **PhotoGrid**: Instagram-style 3-column square grid (`gap: 1px`, `aspect-ratio: 1/1`, `object-fit: cover`); code overlay removed — photos are pure tappable squares
- **DownloadPage**: Simplified to a sticky search bar + grid. Code search now navigates to `/photo/:code` instead of showing an inline result, removing ~70 lines of state management
- **PhotoDetailPage**: iOS-style layout — top nav bar (chevron back + centered code number + spacer), full-flex photo area (`object-fit: contain`), circular icon action buttons at bottom with `env(safe-area-inset-bottom)`
- **Icons.tsx** (new): 4 inline SVG components (`ChevronLeftIcon`, `DownloadIcon`, `ShareIcon`, `SearchIcon`) — no new dependency
- **App.css**: Black background, `100dvh`, `env(safe-area-inset-*)`, `-webkit-tap-highlight-color: transparent`; all old unused styles removed
- **Translations**: Removed 5 unused keys; shortened `enterPhotoCode` placeholder to "Photo code" / "Código de foto"

## Test plan

- [ ] `/download`: edge-to-edge square photo grid, sticky search bar, no heading/divider
- [ ] Typing a code and submitting navigates to `/photo/:code`
- [ ] Tapping a grid photo navigates to `/photo/:code`
- [ ] `/photo/:code`: full photo with chevron back, centered code, icon buttons at bottom
- [ ] Share button only visible on devices supporting Web Share API
- [ ] Language switcher still works
- [ ] No focus highlight on search input or buttons
- [ ] `pnpm run build` and `dotnet test` pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)