### PR TITLE
fix: speed dial for photo actions — fixes share on iPhone (#113)

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -426,6 +426,66 @@ body {
   opacity: 0.7;
 }
 
+.action-button:disabled {
+  cursor: default;
+  opacity: 1;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.action-button.loading svg {
+  animation: spin 0.8s linear infinite;
+}
+
+/* Speed Dial */
+.speed-dial {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.speed-dial-items {
+  position: absolute;
+  bottom: calc(100% + 0.75rem);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+.speed-dial.open .speed-dial-items {
+  pointer-events: auto;
+}
+
+.speed-dial-item {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.speed-dial.open .speed-dial-item:nth-last-child(1) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0s;
+}
+
+.speed-dial.open .speed-dial-item:nth-last-child(2) {
+  opacity: 1;
+  transform: translateY(0);
+  transition-delay: 0.05s;
+}
+
+.action-button.speed-dial-trigger.open {
+  background: #2d2d2d;
+}
+
 /* Gamepad Debug Overlay */
 .gamepad-debug {
   position: fixed;

--- a/src/PhotoBooth.Web/src/api/client.ts
+++ b/src/PhotoBooth.Web/src/api/client.ts
@@ -70,15 +70,3 @@ export async function getAllPhotos(): Promise<PhotoDto[]> {
 
   return response.json();
 }
-
-export async function sharePhoto(photoId: string, code: string): Promise<void> {
-  const response = await fetch(getPhotoImageUrl(photoId));
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch photo: ${response.statusText}`);
-  }
-
-  const blob = await response.blob();
-  const file = new File([blob], `photo-${code}.jpg`, { type: 'image/jpeg' });
-  await navigator.share({ files: [file] });
-}

--- a/src/PhotoBooth.Web/src/components/Icons.tsx
+++ b/src/PhotoBooth.Web/src/components/Icons.tsx
@@ -61,6 +61,41 @@ export function ShareIcon({ size = 24, className }: IconProps) {
   );
 }
 
+export function DotsVerticalIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="none"
+      className={className}
+    >
+      <circle cx="12" cy="5" r="2" />
+      <circle cx="12" cy="12" r="2" />
+      <circle cx="12" cy="19" r="2" />
+    </svg>
+  );
+}
+
+export function SpinnerIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+      <path d="M12 2a10 10 0 0 1 10 10" />
+    </svg>
+  );
+}
+
 export function SearchIcon({ size = 24, className }: IconProps) {
   return (
     <svg

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -5,6 +5,7 @@ export const translations = {
     searching: 'Searching...',
     findPhoto: 'Find Photo',
     photoNotFound: 'Photo not found. Please check your code.',
+    getPhoto: 'Get Photo',
     downloadPhoto: 'Download Photo',
     sharePhoto: 'Share Photo',
 
@@ -30,6 +31,7 @@ export const translations = {
     searching: 'Buscando...',
     findPhoto: 'Buscar Foto',
     photoNotFound: 'Foto no encontrada. Por favor verifica el código.',
+    getPhoto: 'Obtener Foto',
     downloadPhoto: 'Descargar Foto',
     sharePhoto: 'Compartir Foto',
 

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { getPhotoByCode, getPhotoImageUrl, sharePhoto, getAllPhotos } from '../api/client';
+import { getPhotoByCode, getPhotoImageUrl, getAllPhotos } from '../api/client';
 import type { PhotoDto } from '../api/types';
-import { ChevronLeftIcon, DownloadIcon, ShareIcon } from '../components/Icons';
+import { ChevronLeftIcon, DownloadIcon, ShareIcon, DotsVerticalIcon, SpinnerIcon } from '../components/Icons';
 import { useTranslation } from '../i18n/useTranslation';
 import { useSwipeNavigation } from '../hooks/useSwipeNavigation';
+
+type PhotoAction = 'idle' | 'loading' | 'expanded';
 
 export function PhotoDetailPage() {
   const { code } = useParams<{ code: string }>();
@@ -14,6 +16,9 @@ export function PhotoDetailPage() {
   const [loading, setLoading] = useState(!!code);
   const [error, setError] = useState<string | null>(code ? null : t('photoNotFoundError'));
   const [allCodes, setAllCodes] = useState<string[]>([]);
+  const [photoAction, setPhotoAction] = useState<PhotoAction>('idle');
+  const cachedBlob = useRef<Blob | null>(null);
+  const speedDialRef = useRef<HTMLDivElement>(null);
   const canShare = !!(navigator.canShare && navigator.canShare({ files: [new File([''], 'test.jpg', { type: 'image/jpeg' })] }));
   const pageRef = useRef<HTMLDivElement>(null);
 
@@ -46,6 +51,28 @@ export function PhotoDetailPage() {
     }
   }, [code]);
 
+  // Reset speed dial state when navigating to a different photo
+  useEffect(() => {
+    setPhotoAction('idle');
+    cachedBlob.current = null;
+  }, [code]);
+
+  // Collapse speed dial when tapping outside it
+  useEffect(() => {
+    if (photoAction !== 'expanded') return;
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (speedDialRef.current && !speedDialRef.current.contains(e.target as Node)) {
+        setPhotoAction('idle');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [photoAction]);
+
   const currentIndex = allCodes.indexOf(code ?? '');
   const prevCode = currentIndex > 0 ? allCodes[currentIndex - 1] : null;
   const nextCode = currentIndex >= 0 && currentIndex < allCodes.length - 1 ? allCodes[currentIndex + 1] : null;
@@ -60,20 +87,47 @@ export function PhotoDetailPage() {
 
   useSwipeNavigation({ onSwipeLeft: handleSwipeLeft, onSwipeRight: handleSwipeRight, elementRef: pageRef });
 
-  const handleDownload = () => {
+  const handleToggle = async () => {
+    if (photoAction === 'expanded') {
+      setPhotoAction('idle');
+      return;
+    }
+    if (cachedBlob.current) {
+      setPhotoAction('expanded');
+      return;
+    }
     if (!photo) return;
+    setPhotoAction('loading');
+    try {
+      const response = await fetch(getPhotoImageUrl(photo.id));
+      if (!response.ok) throw new Error('Failed to fetch photo');
+      cachedBlob.current = await response.blob();
+      setPhotoAction('expanded');
+    } catch {
+      setPhotoAction('idle');
+    }
+  };
 
+  const handleDownload = () => {
+    if (!photo || !cachedBlob.current) return;
+    const url = URL.createObjectURL(cachedBlob.current);
     const link = document.createElement('a');
-    link.href = getPhotoImageUrl(photo.id);
+    link.href = url;
     link.download = `photo-${photo.code}.jpg`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   };
 
   const handleShare = async () => {
-    if (!photo) return;
-    await sharePhoto(photo.id, photo.code);
+    if (!photo || !cachedBlob.current) return;
+    const file = new File([cachedBlob.current], `photo-${photo.code}.jpg`, { type: 'image/jpeg' });
+    try {
+      await navigator.share({ files: [file] });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return;
+    }
   };
 
   const handleBack = () => {
@@ -119,14 +173,26 @@ export function PhotoDetailPage() {
         />
       </div>
       <div className="photo-detail-actions">
-        <button onClick={handleDownload} className="action-button" aria-label={t('downloadPhoto')}>
-          <DownloadIcon size={24} />
-        </button>
-        {canShare && (
-          <button onClick={handleShare} className="action-button" aria-label={t('sharePhoto')}>
-            <ShareIcon size={24} />
+        <div className={`speed-dial${photoAction === 'expanded' ? ' open' : ''}`} ref={speedDialRef}>
+          <div className="speed-dial-items" aria-hidden={photoAction !== 'expanded'}>
+            {canShare && (
+              <button onClick={handleShare} className="action-button speed-dial-item" aria-label={t('sharePhoto')}>
+                <ShareIcon size={24} />
+              </button>
+            )}
+            <button onClick={handleDownload} className="action-button speed-dial-item" aria-label={t('downloadPhoto')}>
+              <DownloadIcon size={24} />
+            </button>
+          </div>
+          <button
+            onClick={photoAction !== 'loading' ? handleToggle : undefined}
+            className={`action-button speed-dial-trigger${photoAction === 'expanded' ? ' open' : ''}${photoAction === 'loading' ? ' loading' : ''}`}
+            aria-label={t('getPhoto')}
+            disabled={photoAction === 'loading'}
+          >
+            {photoAction === 'loading' ? <SpinnerIcon size={24} /> : <DotsVerticalIcon size={24} />}
           </button>
-        )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces the always-visible Download/Share buttons with a Material-style speed dial (`⋮` overflow button)
- Tapping `⋮` fetches the full-res blob (showing a spinner during load), then animates Download and Share sub-buttons upward
- Each sub-button tap is a fresh user activation, so `navigator.share()` is called synchronously — fixing the iOS transient activation expiry bug
- Blob is cached on first open; subsequent expands are instant (no re-fetch)
- Tapping `⋮` again or anywhere outside collapses the dial
- `canShare = false` (e.g. desktop): only the Download sub-button appears

## Test plan

- [ ] iPhone Safari: tap `⋮` → spinner → sub-buttons appear → tap Share → native share sheet opens
- [ ] iPhone Safari: cancel share sheet → no error
- [ ] iPhone Safari: collapse and re-open → instant (no spinner), share still works
- [ ] Desktop/Android: tap `⋮` → sub-buttons appear → Download works
- [ ] Desktop (no `canShare`): only Download sub-button shown
- [ ] Swipe to next photo → dial resets to `⋮`

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)