### PR TITLE
fix: memoize t() in useTranslation to prevent infinite fetch loops

### DIFF
--- a/src/PhotoBooth.Web/src/i18n/useTranslation.ts
+++ b/src/PhotoBooth.Web/src/i18n/useTranslation.ts
@@ -40,8 +40,10 @@ export function useTranslation() {
     window.history.replaceState({}, '', url.toString());
   }, []);
 
+  const tFn = useCallback((key: TranslationKey) => t[key], [t]);
+
   return {
-    t: (key: TranslationKey) => t[key],
+    t: tFn,
     language,
     setLanguage,
   };


### PR DESCRIPTION
## Summary

- `useTranslation` returned `t` as an inline arrow function, creating a new function reference on every render
- Components with `useEffect([..., t])` (e.g. `PhotoDetailPage`, `PhotoGrid`) re-ran their effects after every state update, causing an infinite loop of API calls
- Wrapping `t` in `useCallback` makes its reference stable across renders, so effects only fire when the language actually changes

## Test plan

- [x] Load a photo detail page (`/photo/1`) and confirm `GET /api/photos/1` is called only once in the network tab
- [x] Load the gallery page and confirm `GET /api/photos` is called only once
- [x] Switch language and confirm translations update correctly
- [x] All existing tests pass (`pnpm run test`)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)