### PR TITLE
fix: skip pre-generating thumbnails larger than original image

### DIFF
--- a/src/PhotoBooth.Infrastructure/Imaging/OpenCvImageResizer.cs
+++ b/src/PhotoBooth.Infrastructure/Imaging/OpenCvImageResizer.cs
@@ -52,6 +52,34 @@ public class OpenCvImageResizer : IImageResizer
         return resized;
     }
 
+    public async Task PreGenerateAllSizesAsync(Guid photoId, CancellationToken ct)
+    {
+        var originalData = await _photoRepository.GetImageDataAsync(photoId, ct);
+        if (originalData is null)
+        {
+            _logger.LogDebug("PreGenerateAllSizesAsync: photo {PhotoId} not found, skipping", photoId);
+            return;
+        }
+
+        int originalWidth;
+        using (var src = Mat.FromImageData(originalData, ImreadModes.Color))
+        {
+            originalWidth = src.Width;
+        }
+
+        var sizesToGenerate = IImageResizer.AllowedWidths.Where(w => w < originalWidth).ToArray();
+        var skipped = IImageResizer.AllowedWidths.Length - sizesToGenerate.Length;
+
+        _logger.LogDebug(
+            "PreGenerateAllSizesAsync: photo {PhotoId} is {Width}px wide, generating {Count} sizes, skipping {Skipped}",
+            photoId, originalWidth, sizesToGenerate.Length, skipped);
+
+        foreach (var width in sizesToGenerate)
+        {
+            await GetResizedImageAsync(photoId, width, ct);
+        }
+    }
+
     private byte[] ResizeImage(byte[] originalData, int targetWidth, Guid photoId)
     {
         using var src = Mat.FromImageData(originalData, ImreadModes.Color);

--- a/tests/PhotoBooth.Infrastructure.Tests/Imaging/OpenCvImageResizerTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Imaging/OpenCvImageResizerTests.cs
@@ -124,6 +124,56 @@ public sealed class OpenCvImageResizerTests
         Assert.AreEqual(100, mat.Width);
     }
 
+    [TestMethod]
+    public async Task PreGenerateAllSizesAsync_WhenPhotoDoesNotExist_GeneratesNoFiles()
+    {
+        await _resizer.PreGenerateAllSizesAsync(Guid.NewGuid(), CancellationToken.None);
+
+        var cacheFiles = Directory.GetFiles(_cacheDirectory);
+        Assert.IsEmpty(cacheFiles);
+    }
+
+    [TestMethod]
+    public async Task PreGenerateAllSizesAsync_WhenImageSmallerThanAllAllowedWidths_GeneratesNoThumbnails()
+    {
+        // 150px wide — all AllowedWidths (200, 400, 800, 1200, 1920) are >= 150
+        var smallJpeg = CreateTestJpeg(width: 150, height: 100);
+        var photoId = await SaveTestPhoto(smallJpeg);
+
+        await _resizer.PreGenerateAllSizesAsync(photoId, CancellationToken.None);
+
+        var cacheFiles = Directory.GetFiles(_cacheDirectory, $"{photoId}_*.jpg");
+        Assert.IsEmpty(cacheFiles);
+    }
+
+    [TestMethod]
+    public async Task PreGenerateAllSizesAsync_WhenImageBetweenAllowedWidths_GeneratesOnlySmallerSizes()
+    {
+        // 600px wide — only 200 and 400 are strictly less than 600
+        var jpeg = CreateTestJpeg(width: 600, height: 400);
+        var photoId = await SaveTestPhoto(jpeg);
+
+        await _resizer.PreGenerateAllSizesAsync(photoId, CancellationToken.None);
+
+        var cacheFiles = Directory.GetFiles(_cacheDirectory, $"{photoId}_*.jpg");
+        Assert.HasCount(2, cacheFiles);
+        Assert.IsTrue(cacheFiles.Any(f => f.Contains("_200.jpg")), "200px thumbnail should exist");
+        Assert.IsTrue(cacheFiles.Any(f => f.Contains("_400.jpg")), "400px thumbnail should exist");
+    }
+
+    [TestMethod]
+    public async Task PreGenerateAllSizesAsync_WhenImageLargerThanAllAllowedWidths_GeneratesAllSizes()
+    {
+        // 4000px wide — all AllowedWidths (200, 400, 800, 1200, 1920) are strictly less than 4000
+        var largeJpeg = CreateTestJpeg(width: 4000, height: 3000);
+        var photoId = await SaveTestPhoto(largeJpeg);
+
+        await _resizer.PreGenerateAllSizesAsync(photoId, CancellationToken.None);
+
+        var cacheFiles = Directory.GetFiles(_cacheDirectory, $"{photoId}_*.jpg");
+        Assert.HasCount(IImageResizer.AllowedWidths.Length, cacheFiles);
+    }
+
     private async Task<Guid> SaveTestPhoto(byte[] jpegData)
     {
         var photo = new Photo


### PR DESCRIPTION
## Summary

- Overrides `PreGenerateAllSizesAsync` in `OpenCvImageResizer` to load the original image once, determine its width, and only generate thumbnail sizes strictly less than the original width
- Avoids wastefully caching redundant copies of the original bytes for all allowed sizes >= the original (previously all 5 sizes were always generated regardless of the source resolution)
- Adds 4 integration tests covering: image smaller than all allowed widths, image between allowed widths, image larger than all allowed widths, and non-existent photo

The on-demand path (`GetResizedImageAsync`) and all frontend CSS were already correct — this fix targets the pre-generation warmup path only.

Closes #114

## Test plan

- [ ] `dotnet build` passes with no warnings
- [ ] `dotnet test` passes (all 10 `OpenCvImageResizerTests` including 4 new cases)
- [ ] Manual: run server with a small test image and confirm `.thumbnails/` only contains the expected subset of files

🤖 Generated with [Claude Code](https://claude.com/claude-code)