### PR TITLE
feat: infinite scroll on gallery page

### DIFF
--- a/src/PhotoBooth.Application/DTOs/PhotoDto.cs
+++ b/src/PhotoBooth.Application/DTOs/PhotoDto.cs
@@ -1,3 +1,5 @@
 namespace PhotoBooth.Application.DTOs;
 
 public record PhotoDto(Guid Id, string Code, DateTime CapturedAt);
+
+public record PhotoPageDto(IReadOnlyList<PhotoDto> Photos, string? NextCursor);

--- a/src/PhotoBooth.Application/Services/IPhotoCaptureService.cs
+++ b/src/PhotoBooth.Application/Services/IPhotoCaptureService.cs
@@ -8,4 +8,5 @@ public interface IPhotoCaptureService
     Task<PhotoDto?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
     Task<byte[]?> GetImageDataAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<PhotoDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<PhotoPageDto> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default);
 }

--- a/src/PhotoBooth.Application/Services/PhotoCaptureService.cs
+++ b/src/PhotoBooth.Application/Services/PhotoCaptureService.cs
@@ -81,4 +81,25 @@ public class PhotoCaptureService : IPhotoCaptureService
         var photos = await _photoRepository.GetAllAsync(cancellationToken);
         return photos.Select(p => new PhotoDto(p.Id, p.Code, p.CapturedAt)).ToList();
     }
+
+    public async Task<PhotoPageDto> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Retrieving photo page: limit={Limit}, cursor={Cursor}", limit, cursor);
+        var photos = await _photoRepository.GetPageAsync(limit + 1, cursor, cancellationToken);
+
+        string? nextCursor = null;
+        IReadOnlyList<PhotoDto> page;
+
+        if (photos.Count > limit)
+        {
+            page = photos.Take(limit).Select(p => new PhotoDto(p.Id, p.Code, p.CapturedAt)).ToList();
+            nextCursor = photos[limit - 1].Code;
+        }
+        else
+        {
+            page = photos.Select(p => new PhotoDto(p.Id, p.Code, p.CapturedAt)).ToList();
+        }
+
+        return new PhotoPageDto(page, nextCursor);
+    }
 }

--- a/src/PhotoBooth.Domain/Interfaces/IPhotoRepository.cs
+++ b/src/PhotoBooth.Domain/Interfaces/IPhotoRepository.cs
@@ -11,4 +11,5 @@ public interface IPhotoRepository
     Task<Photo?> GetRandomAsync(CancellationToken cancellationToken = default);
     Task<int> GetCountAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Photo>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Photo>> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default);
 }

--- a/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
+++ b/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
@@ -94,6 +94,17 @@ public class FileSystemPhotoRepository : IPhotoRepository
         return photos.OrderBy(p => int.TryParse(p.Code, out var code) ? code : int.MaxValue).ToList();
     }
 
+    public async Task<IReadOnlyList<Photo>> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        var photos = await GetPhotosAsync(cancellationToken);
+        var cursorValue = cursor is not null && int.TryParse(cursor, out var c) ? c : int.MaxValue;
+        return photos
+            .Where(p => int.TryParse(p.Code, out var code) && code < cursorValue)
+            .OrderByDescending(p => int.Parse(p.Code))
+            .Take(limit)
+            .ToList();
+    }
+
     private async Task<List<Photo>> GetPhotosAsync(CancellationToken cancellationToken)
     {
         if (_photosCache is not null)

--- a/src/PhotoBooth.Infrastructure/Storage/InMemoryPhotoRepository.cs
+++ b/src/PhotoBooth.Infrastructure/Storage/InMemoryPhotoRepository.cs
@@ -73,4 +73,18 @@ public class InMemoryPhotoRepository : IPhotoRepository
                 _photos.OrderBy(p => int.TryParse(p.Code, out var code) ? code : int.MaxValue).ToList());
         }
     }
+
+    public Task<IReadOnlyList<Photo>> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            var cursorValue = cursor is not null && int.TryParse(cursor, out var c) ? c : int.MaxValue;
+            var page = _photos
+                .Where(p => int.TryParse(p.Code, out var code) && code < cursorValue)
+                .OrderByDescending(p => int.Parse(p.Code))
+                .Take(limit)
+                .ToList();
+            return Task.FromResult<IReadOnlyList<Photo>>(page);
+        }
+    }
 }

--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -105,8 +105,16 @@ public static class PhotoEndpoints
 
     private static async Task<IResult> GetAllPhotos(
         IPhotoCaptureService captureService,
+        int? limit,
+        string? cursor,
         CancellationToken cancellationToken)
     {
+        if (limit > 0)
+        {
+            var page = await captureService.GetPageAsync(limit.Value, cursor, cancellationToken);
+            return Results.Ok(page);
+        }
+
         var photos = await captureService.GetAllAsync(cancellationToken);
         return Results.Ok(photos);
     }

--- a/src/PhotoBooth.Web/src/api/client.ts
+++ b/src/PhotoBooth.Web/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ClientConfigDto, PhotoDto, SlideshowPhotoDto, TriggerResponse } from './types';
+import type { ClientConfigDto, PhotoDto, PhotoPageDto, SlideshowPhotoDto, TriggerResponse } from './types';
 
 const API_BASE = '/api';
 
@@ -63,6 +63,18 @@ export async function getClientConfig(): Promise<ClientConfigDto> {
 
 export async function getAllPhotos(): Promise<PhotoDto[]> {
   const response = await fetch(`${API_BASE}/photos`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to get photos: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function getPhotosPage(limit: number, cursor?: string): Promise<PhotoPageDto> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor) params.set('cursor', cursor);
+  const response = await fetch(`${API_BASE}/photos?${params}`);
 
   if (!response.ok) {
     throw new Error(`Failed to get photos: ${response.statusText}`);

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -4,6 +4,11 @@ export interface PhotoDto {
   capturedAt: string;
 }
 
+export interface PhotoPageDto {
+  photos: PhotoDto[];
+  nextCursor: string | null;
+}
+
 export interface SlideshowPhotoDto {
   id: string;
   code: string;

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from 'react';
-import { getAllPhotos, getPhotoImageUrl } from '../api/client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { getPhotosPage, getPhotoImageUrl } from '../api/client';
 import type { PhotoDto } from '../api/types';
 import { useTranslation } from '../i18n/useTranslation';
+
+const PAGE_SIZE = 30;
 
 interface PhotoGridProps {
   onPhotoClick: (code: string) => void;
@@ -11,14 +13,47 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   const { t } = useTranslation();
   const [photos, setPhotos] = useState<PhotoDto[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null | undefined>(undefined);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    getAllPhotos()
-      .then(setPhotos)
+    getPhotosPage(PAGE_SIZE)
+      .then(page => {
+        setPhotos(page.photos);
+        setNextCursor(page.nextCursor);
+      })
       .catch(err => setError(err instanceof Error ? err.message : t('failedToLoadPhotos')))
       .finally(() => setLoading(false));
   }, [t]);
+
+  const loadMore = useCallback(() => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    getPhotosPage(PAGE_SIZE, nextCursor)
+      .then(page => {
+        setPhotos(prev => [...prev, ...page.photos]);
+        setNextCursor(page.nextCursor);
+      })
+      .catch(err => setError(err instanceof Error ? err.message : t('failedToLoadPhotos')))
+      .finally(() => setLoadingMore(false));
+  }, [nextCursor, loadingMore, t]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   if (loading) {
     return <div className="photo-grid-loading">{t('loadingPhotos')}</div>;
@@ -47,6 +82,11 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
           />
         </div>
       ))}
+      {nextCursor && (
+        <div ref={sentinelRef} className="photo-grid-loading">
+          {loadingMore ? t('loadingPhotos') : ''}
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoCaptureService.cs
+++ b/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoCaptureService.cs
@@ -27,4 +27,7 @@ public sealed class StubPhotoCaptureService : IPhotoCaptureService
 
     public Task<IReadOnlyList<PhotoDto>> GetAllAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<PhotoDto>>([]);
+
+    public Task<PhotoPageDto> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default)
+        => Task.FromResult(new PhotoPageDto([], null));
 }

--- a/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoRepository.cs
+++ b/tests/PhotoBooth.Application.Tests/TestDoubles/StubPhotoRepository.cs
@@ -37,4 +37,16 @@ public sealed class StubPhotoRepository : IPhotoRepository
 
     public Task<IReadOnlyList<Photo>> GetAllAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<Photo>>(_photos.Values.Select(p => p.Photo).OrderBy(p => int.TryParse(p.Code, out var code) ? code : int.MaxValue).ToList());
+
+    public Task<IReadOnlyList<Photo>> GetPageAsync(int limit, string? cursor = null, CancellationToken cancellationToken = default)
+    {
+        var cursorValue = cursor is not null && int.TryParse(cursor, out var c) ? c : int.MaxValue;
+        var page = _photos.Values
+            .Select(p => p.Photo)
+            .Where(p => int.TryParse(p.Code, out var code) && code < cursorValue)
+            .OrderByDescending(p => int.Parse(p.Code))
+            .Take(limit)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Photo>>(page);
+    }
 }

--- a/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
@@ -184,7 +184,92 @@ public sealed class PhotoEndpointsTests
         // Lowest code number should be first (oldest photo)
         Assert.AreEqual(firstCaptureResult!.Code, photos[0].Code);
     }
+
+    [TestMethod]
+    public async Task GetPhotosPage_ReturnsCorrectPageSizeAndNextCursor()
+    {
+        // Arrange - capture 5 photos
+        for (var i = 0; i < 5; i++)
+        {
+            await _client.PostAsync("/api/photos/capture", null);
+        }
+
+        // Act - request first page of 3
+        var response = await _client.GetAsync("/api/photos?limit=3");
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PhotoPageDto>();
+        Assert.IsNotNull(page);
+        Assert.HasCount(3, page.Photos);
+        Assert.IsNotNull(page.NextCursor);
+    }
+
+    [TestMethod]
+    public async Task GetPhotosPage_SecondPageReturnRemainingPhotos()
+    {
+        // Arrange - capture 5 photos
+        for (var i = 0; i < 5; i++)
+        {
+            await _client.PostAsync("/api/photos/capture", null);
+        }
+
+        // Act - get first page then second page
+        var firstPageResponse = await _client.GetAsync("/api/photos?limit=3");
+        var firstPage = await firstPageResponse.Content.ReadFromJsonAsync<PhotoPageDto>();
+        Assert.IsNotNull(firstPage?.NextCursor);
+
+        var secondPageResponse = await _client.GetAsync($"/api/photos?limit=3&cursor={firstPage.NextCursor}");
+        var secondPage = await secondPageResponse.Content.ReadFromJsonAsync<PhotoPageDto>();
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, secondPageResponse.StatusCode);
+        Assert.IsNotNull(secondPage);
+        Assert.HasCount(2, secondPage.Photos);
+        Assert.IsNull(secondPage.NextCursor);
+    }
+
+    [TestMethod]
+    public async Task GetPhotosPage_ReturnsNewestFirst()
+    {
+        // Arrange - capture 3 photos
+        var captures = new List<CaptureResultDto>();
+        for (var i = 0; i < 3; i++)
+        {
+            var res = await _client.PostAsync("/api/photos/capture", null);
+            var dto = await res.Content.ReadFromJsonAsync<CaptureResultDto>();
+            captures.Add(dto!);
+        }
+
+        // Act
+        var response = await _client.GetAsync("/api/photos?limit=3");
+        var page = await response.Content.ReadFromJsonAsync<PhotoPageDto>();
+
+        // Assert - newest (highest code) should be first
+        Assert.IsNotNull(page);
+        var codes = page.Photos.Select(p => int.Parse(p.Code)).ToList();
+        Assert.IsTrue(codes[0] > codes[1] && codes[1] > codes[2], "Photos should be newest-first (descending code)");
+    }
+
+    [TestMethod]
+    public async Task GetPhotosPage_WhenFewerPhotosThanLimit_HasNoNextCursor()
+    {
+        // Arrange - capture 2 photos
+        await _client.PostAsync("/api/photos/capture", null);
+        await _client.PostAsync("/api/photos/capture", null);
+
+        // Act
+        var response = await _client.GetAsync("/api/photos?limit=10");
+        var page = await response.Content.ReadFromJsonAsync<PhotoPageDto>();
+
+        // Assert
+        Assert.IsNotNull(page);
+        Assert.HasCount(2, page.Photos);
+        Assert.IsNull(page.NextCursor);
+    }
 }
+
+file record PhotoPageDto(List<PhotoDto> Photos, string? NextCursor);
 
 /// <summary>
 /// Test implementation that passes through to IPhotoRepository without actual resizing.


### PR DESCRIPTION
## Summary

- Adds cursor-based pagination to `GET /api/photos` via optional `limit` and `cursor` query params; returns `PhotoPageDto` (newest-first) when `limit > 0`, preserving the existing flat array response for backward compat
- `PhotoGrid` replaces a single bulk fetch with `IntersectionObserver`-based infinite scroll loading 30 photos per batch, pre-loading 200px before the sentinel reaches the viewport
- `PhotoDetailPage` (swipe navigation) is unchanged — it continues using `getAllPhotos()` since the full code list is needed for prev/next

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — all 135 tests pass (4 new integration tests for pagination)
- [x] `pnpm run build` — frontend builds cleanly
- [x] Manual: navigate to `/download`, verify photos load in batches as you scroll to the bottom

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)