### PR TITLE
feat: watchdog system for resilience during long-running events

### DIFF
--- a/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
+++ b/src/PhotoBooth.Application/DTOs/ClientConfigDto.cs
@@ -19,4 +19,5 @@ public record ClientConfigDto(
     string? QrCodeBaseUrl,
     bool SwirlEffect,
     int SlideshowIntervalMs,
-    GamepadConfigDto Gamepad);
+    GamepadConfigDto Gamepad,
+    int WatchdogTimeoutMs);

--- a/src/PhotoBooth.Application/Services/IActivityTracker.cs
+++ b/src/PhotoBooth.Application/Services/IActivityTracker.cs
@@ -1,0 +1,7 @@
+namespace PhotoBooth.Application.Services;
+
+public interface IActivityTracker
+{
+    void RecordActivity();
+    TimeSpan TimeSinceLastActivity { get; }
+}

--- a/src/PhotoBooth.Infrastructure/Monitoring/ActivityTracker.cs
+++ b/src/PhotoBooth.Infrastructure/Monitoring/ActivityTracker.cs
@@ -1,0 +1,16 @@
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Infrastructure.Monitoring;
+
+public sealed class ActivityTracker : IActivityTracker
+{
+    private long _lastActivityTick = Environment.TickCount64;
+
+    public void RecordActivity()
+    {
+        Interlocked.Exchange(ref _lastActivityTick, Environment.TickCount64);
+    }
+
+    public TimeSpan TimeSinceLastActivity =>
+        TimeSpan.FromMilliseconds(Environment.TickCount64 - Interlocked.Read(ref _lastActivityTick));
+}

--- a/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/ConfigEndpoints.cs
@@ -37,7 +37,9 @@ public static class ConfigEndpoints
             Threshold: dpadAxesSection.GetValue<double>("Threshold", 0.5));
         var gamepad = new GamepadConfigDto(gamepadEnabled, gamepadDebugMode, buttons, dpadAxes);
 
-        var config = new ClientConfigDto(qrCodeBaseUrl, swirlEffect, slideshowIntervalMs, gamepad);
+        var watchdogTimeoutMs = configuration.GetValue<int?>("Watchdog:ClientTimeoutMs") ?? 300000;
+
+        var config = new ClientConfigDto(qrCodeBaseUrl, swirlEffect, slideshowIntervalMs, gamepad, watchdogTimeoutMs);
         return Results.Ok(config);
     }
 }

--- a/src/PhotoBooth.Server/Endpoints/EventsEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/EventsEndpoints.cs
@@ -20,27 +20,73 @@ public static class EventsEndpoints
     private static async Task HandleSseConnection(
         HttpContext context,
         IEventBroadcaster eventBroadcaster,
+        IConfiguration configuration,
         CancellationToken cancellationToken)
     {
         context.Response.ContentType = "text/event-stream";
         context.Response.Headers.CacheControl = "no-cache";
         context.Response.Headers.Connection = "keep-alive";
 
+        var heartbeatIntervalSeconds = configuration.GetValue<int?>("Watchdog:SseHeartbeatIntervalSeconds") ?? 30;
+        var writeLock = new SemaphoreSlim(1, 1);
+
         // Send initial connection event
         await WriteEventAsync(context.Response, "connected", new { message = "Connected to event stream" }, cancellationToken);
         await context.Response.Body.FlushAsync(cancellationToken);
+
+        var heartbeatTask = RunHeartbeatAsync(context.Response, writeLock, heartbeatIntervalSeconds, cancellationToken);
 
         try
         {
             await foreach (var evt in eventBroadcaster.SubscribeAsync(cancellationToken))
             {
-                await WriteEventAsync(context.Response, evt.EventType, evt, cancellationToken);
-                await context.Response.Body.FlushAsync(cancellationToken);
+                await writeLock.WaitAsync(cancellationToken);
+                try
+                {
+                    await WriteEventAsync(context.Response, evt.EventType, evt, cancellationToken);
+                    await context.Response.Body.FlushAsync(cancellationToken);
+                }
+                finally
+                {
+                    writeLock.Release();
+                }
             }
         }
         catch (OperationCanceledException)
         {
             // Client disconnected, this is expected
+        }
+
+        await heartbeatTask;
+    }
+
+    private static async Task RunHeartbeatAsync(
+        HttpResponse response,
+        SemaphoreSlim writeLock,
+        int intervalSeconds,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), cancellationToken);
+
+                await writeLock.WaitAsync(cancellationToken);
+                try
+                {
+                    await response.WriteAsync(":heartbeat\n\n", cancellationToken);
+                    await response.Body.FlushAsync(cancellationToken);
+                }
+                finally
+                {
+                    writeLock.Release();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when cancellation is requested
         }
     }
 

--- a/src/PhotoBooth.Server/InactivityWatchdogService.cs
+++ b/src/PhotoBooth.Server/InactivityWatchdogService.cs
@@ -1,0 +1,63 @@
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Server;
+
+public sealed class InactivityWatchdogService : BackgroundService
+{
+    private readonly IActivityTracker _activityTracker;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<InactivityWatchdogService> _logger;
+    private readonly TimeSpan _inactivityThreshold;
+    private readonly TimeSpan _checkInterval;
+
+    public InactivityWatchdogService(
+        IActivityTracker activityTracker,
+        IHostApplicationLifetime lifetime,
+        IConfiguration configuration,
+        ILogger<InactivityWatchdogService> logger,
+        TimeSpan? checkInterval = null)
+    {
+        _activityTracker = activityTracker;
+        _lifetime = lifetime;
+        _logger = logger;
+        _checkInterval = checkInterval ?? TimeSpan.FromSeconds(60);
+
+        var minutes = configuration.GetValue<int?>("Watchdog:ServerInactivityMinutes") ?? 30;
+        _inactivityThreshold = TimeSpan.FromMinutes(minutes);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_inactivityThreshold == TimeSpan.Zero)
+        {
+            _logger.LogInformation("Inactivity watchdog is disabled (threshold = 0)");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Inactivity watchdog started (threshold: {Minutes} minutes, check interval: {Seconds}s)",
+            _inactivityThreshold.TotalMinutes, _checkInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_checkInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            var inactivity = _activityTracker.TimeSinceLastActivity;
+            if (inactivity > _inactivityThreshold)
+            {
+                _logger.LogWarning(
+                    "No API activity for {Minutes:F1} minutes (threshold: {Threshold} minutes). Shutting down for restart.",
+                    inactivity.TotalMinutes, _inactivityThreshold.TotalMinutes);
+                _lifetime.StopApplication();
+                return;
+            }
+        }
+    }
+}

--- a/src/PhotoBooth.Server/Middleware/ActivityTrackingMiddleware.cs
+++ b/src/PhotoBooth.Server/Middleware/ActivityTrackingMiddleware.cs
@@ -1,0 +1,34 @@
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Server.Middleware;
+
+public sealed class ActivityTrackingMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public ActivityTrackingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public Task InvokeAsync(HttpContext context, IActivityTracker activityTracker)
+    {
+        var path = context.Request.Path.Value ?? string.Empty;
+
+        if (path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase)
+            && !path.Equals("/api/events", StringComparison.OrdinalIgnoreCase))
+        {
+            activityTracker.RecordActivity();
+        }
+
+        return _next(context);
+    }
+}
+
+public static class ActivityTrackingExtensions
+{
+    public static IApplicationBuilder UseActivityTracking(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<ActivityTrackingMiddleware>();
+    }
+}

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -8,6 +8,7 @@ using PhotoBooth.Infrastructure.CodeGeneration;
 using PhotoBooth.Infrastructure.Events;
 using PhotoBooth.Infrastructure.Imaging;
 using PhotoBooth.Infrastructure.Input;
+using PhotoBooth.Infrastructure.Monitoring;
 using PhotoBooth.Infrastructure.Network;
 using PhotoBooth.Infrastructure.Storage;
 using PhotoBooth.Server.Endpoints;
@@ -128,6 +129,16 @@ builder.Services.AddSingleton<ICaptureWorkflowService>(sp =>
 // Register thumbnail warmup service
 builder.Services.AddHostedService<ThumbnailWarmupService>();
 
+// Register activity tracker
+builder.Services.AddSingleton<IActivityTracker, ActivityTracker>();
+
+// Register inactivity watchdog (disabled if threshold is 0)
+var watchdogInactivityMinutes = builder.Configuration.GetValue<int?>("Watchdog:ServerInactivityMinutes") ?? 30;
+if (watchdogInactivityMinutes > 0)
+{
+    builder.Services.AddHostedService<InactivityWatchdogService>();
+}
+
 // Register input providers and manager
 var enableKeyboardInput = builder.Configuration.GetValue<bool>("Input:EnableKeyboard");
 if (enableKeyboardInput)
@@ -177,6 +188,9 @@ else
 
 // Security headers (before static files so headers apply to all responses)
 app.UseSecurityHeaders();
+
+// Activity tracking (records API calls for inactivity watchdog)
+app.UseActivityTracking();
 
 // Redirect non-localhost users from / to /download (gallery)
 var restrictBoothToLocalhost = builder.Configuration.GetValue<bool?>("Booth:RestrictToLocalhost") ?? true;

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -150,5 +150,15 @@
     "PermitLimit": 5,
     // Fixed window duration in seconds
     "WindowSeconds": 10
+  },
+
+  // Watchdog settings
+  "Watchdog": {
+    // Minutes of API inactivity before server shuts down for restart (0 = disabled)
+    "ServerInactivityMinutes": 30,
+    // Client-side: ms of user inactivity before booth page reloads
+    "ClientTimeoutMs": 300000,
+    // Seconds between SSE heartbeat comments
+    "SseHeartbeatIntervalSeconds": 30
   }
 }

--- a/src/PhotoBooth.Web/src/App.tsx
+++ b/src/PhotoBooth.Web/src/App.tsx
@@ -12,6 +12,7 @@ function App() {
   const [swirlEffect, setSwirlEffect] = useState(true);
   const [slideshowIntervalMs, setSlideshowIntervalMs] = useState(30000);
   const [gamepadConfig, setGamepadConfig] = useState<GamepadConfig | null>(null);
+  const [watchdogTimeoutMs, setWatchdogTimeoutMs] = useState(300000);
 
   useEffect(() => {
     getClientConfig()
@@ -22,6 +23,7 @@ function App() {
         setSwirlEffect(config.swirlEffect);
         setSlideshowIntervalMs(config.slideshowIntervalMs);
         setGamepadConfig(config.gamepad);
+        setWatchdogTimeoutMs(config.watchdogTimeoutMs);
       })
       .catch(err => {
         console.error('Failed to load client config:', err);
@@ -32,7 +34,7 @@ function App() {
     <BrowserRouter>
       <div className="app">
         <Routes>
-          <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} slideshowIntervalMs={slideshowIntervalMs} gamepadConfig={gamepadConfig} />} />
+          <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} slideshowIntervalMs={slideshowIntervalMs} gamepadConfig={gamepadConfig} watchdogTimeoutMs={watchdogTimeoutMs} />} />
           <Route path="/download" element={<DownloadPage />} />
           <Route path="/photo/:code" element={<PhotoDetailPage />} />
         </Routes>

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -92,4 +92,5 @@ export interface ClientConfigDto {
   swirlEffect: boolean;
   slideshowIntervalMs: number;
   gamepad: GamepadConfig;
+  watchdogTimeoutMs: number;
 }

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -11,9 +11,9 @@ import type { GamepadDebugEvent } from '../hooks/useGamepadNavigation';
 import type { PhotoBoothEvent, QueuedPhoto, GamepadConfig } from '../api/types';
 
 const DEFAULT_SLIDESHOW_INTERVAL_MS = 30000;
+const DEFAULT_WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000;
 const ERROR_DISPLAY_MS = 3000;
 const FADE_DURATION_MS = 500;
-const WATCHDOG_RELOAD_MS = 5 * 60 * 1000;
 const GAMEPAD_DEBUG_DISPLAY_MS = 3000;
 
 interface BoothPageProps {
@@ -21,6 +21,7 @@ interface BoothPageProps {
   swirlEffect?: boolean;
   slideshowIntervalMs?: number;
   gamepadConfig?: GamepadConfig | null;
+  watchdogTimeoutMs?: number;
 }
 
 function randomInRange(min: number, max: number): number {
@@ -76,7 +77,7 @@ interface DisplayPhoto {
   fromQueue: boolean; // true if from queue, false if newly captured
 }
 
-export function BoothPage({ qrCodeBaseUrl, swirlEffect = true, slideshowIntervalMs = DEFAULT_SLIDESHOW_INTERVAL_MS, gamepadConfig }: BoothPageProps) {
+export function BoothPage({ qrCodeBaseUrl, swirlEffect = true, slideshowIntervalMs = DEFAULT_SLIDESHOW_INTERVAL_MS, gamepadConfig, watchdogTimeoutMs = DEFAULT_WATCHDOG_TIMEOUT_MS }: BoothPageProps) {
   // Queue of interrupted photos waiting to be displayed
   const [photoQueue, setPhotoQueue] = useState<QueuedPhoto[]>([]);
   // Current index within the queue
@@ -126,10 +127,10 @@ export function BoothPage({ qrCodeBaseUrl, swirlEffect = true, slideshowInterval
       clearTimeout(watchdogTimeoutRef.current);
     }
     watchdogTimeoutRef.current = window.setTimeout(() => {
-      console.log('Watchdog: No interaction for 5 minutes, reloading page...');
+      console.log(`Watchdog: No interaction for ${watchdogTimeoutMs / 1000}s, reloading page...`);
       window.location.reload();
-    }, WATCHDOG_RELOAD_MS);
-  }, []);
+    }, watchdogTimeoutMs);
+  }, [watchdogTimeoutMs]);
 
   useEffect(() => {
     resetWatchdog();

--- a/tests/PhotoBooth.Infrastructure.Tests/Monitoring/ActivityTrackerTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Monitoring/ActivityTrackerTests.cs
@@ -1,0 +1,44 @@
+using PhotoBooth.Infrastructure.Monitoring;
+
+namespace PhotoBooth.Infrastructure.Tests.Monitoring;
+
+[TestClass]
+public class ActivityTrackerTests
+{
+    [TestMethod]
+    public void InitialTimeSinceLastActivity_IsNearZero()
+    {
+        var tracker = new ActivityTracker();
+
+        Assert.IsTrue(tracker.TimeSinceLastActivity < TimeSpan.FromSeconds(1),
+            $"Expected near-zero initial inactivity, got {tracker.TimeSinceLastActivity}");
+    }
+
+    [TestMethod]
+    public void RecordActivity_ResetsTimeSinceLastActivity()
+    {
+        var tracker = new ActivityTracker();
+
+        // Wait a moment so there is measurable elapsed time
+        Thread.Sleep(50);
+        var before = tracker.TimeSinceLastActivity;
+
+        tracker.RecordActivity();
+        var after = tracker.TimeSinceLastActivity;
+
+        Assert.IsTrue(after < before,
+            $"Expected TimeSinceLastActivity to decrease after RecordActivity. Before: {before}, After: {after}");
+    }
+
+    [TestMethod]
+    public async Task RecordActivity_ConcurrentCalls_DoNotThrow()
+    {
+        var tracker = new ActivityTracker();
+
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() => tracker.RecordActivity()));
+        await Task.WhenAll(tasks);
+
+        // If we get here without exception, concurrency is handled correctly
+        Assert.IsTrue(tracker.TimeSinceLastActivity < TimeSpan.FromSeconds(5));
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/ConfigEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/ConfigEndpointsTests.cs
@@ -22,6 +22,7 @@ public sealed class ConfigEndpointsTests
         Assert.IsNotNull(config);
         Assert.IsTrue(config.SwirlEffect, "SwirlEffect should default to true");
         Assert.IsTrue(string.IsNullOrEmpty(config.QrCodeBaseUrl), "QrCodeBaseUrl should default to empty");
+        Assert.AreEqual(300000, config.WatchdogTimeoutMs, "WatchdogTimeoutMs should default to 300000");
     }
 
     [TestMethod]

--- a/tests/PhotoBooth.Server.Tests/EventsEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/EventsEndpointsTests.cs
@@ -45,6 +45,34 @@ public sealed class EventsEndpointsTests
     }
 
     [TestMethod]
+    public async Task EventStream_ReceivesHeartbeatComment_WithinConfiguredInterval()
+    {
+        using var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("Watchdog:SseHeartbeatIntervalSeconds", "1");
+            });
+        using var client = factory.CreateClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/events");
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        using var stream = await response.Content.ReadAsStreamAsync();
+        using var reader = new StreamReader(stream);
+
+        // Skip the connected event (event line + data line + blank line)
+        await reader.ReadLineAsync(); // event: connected
+        await reader.ReadLineAsync(); // data: ...
+        await reader.ReadLineAsync(); // blank line
+
+        // Wait for heartbeat comment (interval is 1s, allow 5s timeout)
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var line = await reader.ReadLineAsync(cts.Token);
+
+        Assert.IsNotNull(line);
+        Assert.AreEqual(":heartbeat", line);
+    }
+
+    [TestMethod]
     public async Task EventStream_ReceivesBroadcastedEvent()
     {
         using var factory = new WebApplicationFactory<Program>();

--- a/tests/PhotoBooth.Server.Tests/InactivityWatchdogServiceTests.cs
+++ b/tests/PhotoBooth.Server.Tests/InactivityWatchdogServiceTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public class InactivityWatchdogServiceTests
+{
+    private sealed class FakeActivityTracker : IActivityTracker
+    {
+        public TimeSpan TimeSinceLastActivity { get; set; }
+        public void RecordActivity() { }
+    }
+
+    private sealed class FakeApplicationLifetime : IHostApplicationLifetime
+    {
+        private readonly CancellationTokenSource _startedSource = new();
+        private readonly CancellationTokenSource _stoppingSource = new();
+        private readonly CancellationTokenSource _stoppedSource = new();
+
+        public bool StopApplicationCalled { get; private set; }
+        public CancellationToken ApplicationStarted => _startedSource.Token;
+        public CancellationToken ApplicationStopping => _stoppingSource.Token;
+        public CancellationToken ApplicationStopped => _stoppedSource.Token;
+
+        public void StopApplication() => StopApplicationCalled = true;
+    }
+
+    private static IConfiguration BuildConfig(int inactivityMinutes) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Watchdog:ServerInactivityMinutes"] = inactivityMinutes.ToString()
+            })
+            .Build();
+
+    [TestMethod]
+    public async Task WatchdogService_CallsStopApplication_WhenInactivityThresholdExceeded()
+    {
+        var fakeTracker = new FakeActivityTracker { TimeSinceLastActivity = TimeSpan.FromMinutes(31) };
+        var fakeLifetime = new FakeApplicationLifetime();
+        var config = BuildConfig(30);
+        var logger = NullLogger<InactivityWatchdogService>.Instance;
+
+        var service = new InactivityWatchdogService(
+            fakeTracker, fakeLifetime, config, logger,
+            checkInterval: TimeSpan.FromMilliseconds(50));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await service.StartAsync(cts.Token);
+
+        // Wait long enough for at least one check to complete
+        await Task.Delay(300, CancellationToken.None);
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(fakeLifetime.StopApplicationCalled,
+            "StopApplication should have been called when inactivity exceeded the threshold");
+    }
+
+    [TestMethod]
+    public async Task WatchdogService_DoesNotCallStopApplication_WhenActivityContinues()
+    {
+        var fakeTracker = new FakeActivityTracker { TimeSinceLastActivity = TimeSpan.FromMinutes(5) };
+        var fakeLifetime = new FakeApplicationLifetime();
+        var config = BuildConfig(30);
+        var logger = NullLogger<InactivityWatchdogService>.Instance;
+
+        var service = new InactivityWatchdogService(
+            fakeTracker, fakeLifetime, config, logger,
+            checkInterval: TimeSpan.FromMilliseconds(50));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await service.StartAsync(cts.Token);
+
+        // Run a few check cycles
+        await Task.Delay(300, CancellationToken.None);
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.IsFalse(fakeLifetime.StopApplicationCalled,
+            "StopApplication should not have been called when activity is within threshold");
+    }
+
+    [TestMethod]
+    public async Task WatchdogService_Disabled_WhenThresholdIsZero()
+    {
+        var fakeTracker = new FakeActivityTracker { TimeSinceLastActivity = TimeSpan.FromHours(24) };
+        var fakeLifetime = new FakeApplicationLifetime();
+        var config = BuildConfig(0);
+        var logger = NullLogger<InactivityWatchdogService>.Instance;
+
+        var service = new InactivityWatchdogService(
+            fakeTracker, fakeLifetime, config, logger,
+            checkInterval: TimeSpan.FromMilliseconds(50));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await service.StartAsync(cts.Token);
+        await Task.Delay(300, CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.IsFalse(fakeLifetime.StopApplicationCalled,
+            "StopApplication should not be called when watchdog is disabled (threshold = 0)");
+    }
+}


### PR DESCRIPTION
## Summary

- **Server-side inactivity watchdog**: `InactivityWatchdogService` checks API activity every 60s and calls `StopApplication()` when idle beyond the configured threshold (default: 30 min), relying on an external supervisor to restart the process. Disabled when `Watchdog:ServerInactivityMinutes` is 0.
- **Activity tracking middleware**: `ActivityTrackingMiddleware` records every `/api/*` request except `/api/events` (SSE is a persistent connection, not user-initiated activity).
- **SSE heartbeat**: `/api/events` now sends `:heartbeat` SSE comments every 30s (configurable), helping clients detect stale TCP connections faster. Heartbeat and event writes are synchronized via `SemaphoreSlim`.
- **Configurable client watchdog**: The booth page reload timeout is no longer hardcoded — it is now served via `GET /api/config` as `watchdogTimeoutMs` (default: 300000 ms / 5 min).

New config section in `appsettings.json`:
```jsonc
"Watchdog": {
  "ServerInactivityMinutes": 30,   // 0 = disabled
  "ClientTimeoutMs": 300000,
  "SseHeartbeatIntervalSeconds": 30
}
```

## Test plan

- [x] `dotnet build` — all projects compile cleanly
- [x] `dotnet test` — all 142 tests pass (10 Application, 50 Server, 82 Infrastructure)
- [x] `pnpm run build` — frontend builds without errors
- [ ] Manual: start server, open `/api/events` in browser, confirm `:heartbeat` comments appear every ~30s
- [ ] Manual: `GET /api/config` returns `watchdogTimeoutMs: 300000`
- [ ] Manual: set `Watchdog:ServerInactivityMinutes` to a small value, verify server shuts down after inactivity

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)