### PR TITLE
feat: add NuGet package caching to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Restore .NET dependencies
         run: dotnet restore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ jobs:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` step to the `dotnet` job in `ci.yml` to cache NuGet packages between runs
- Add the same cache step to `release.yml` before the publish step

Cache key is based on OS and a hash of all `.csproj` files and `Directory.Packages.props`, with a fallback restore key of `nuget-{os}-`.

## Test plan
- [x] Verify CI workflow passes on this PR
- [x] On a second run (or re-run), confirm the "Cache NuGet packages" step shows a cache hit

Closes #146