### PR TITLE
feat: add test and lint steps to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,17 @@ jobs:
         working-directory: src/PhotoBooth.Web
         run: pnpm run build
 
+      - name: Lint frontend
+        working-directory: src/PhotoBooth.Web
+        run: pnpm run lint
+
+      - name: Test frontend
+        working-directory: src/PhotoBooth.Web
+        run: pnpm run test
+
+      - name: Test .NET
+        run: dotnet test --verbosity normal --filter "TestCategory!=Integration"
+
       - name: Determine version
         id: version
         run: |


### PR DESCRIPTION
## Summary

- Adds frontend lint (`pnpm run lint`) to the release workflow
- Adds frontend tests (`pnpm run test`) to the release workflow
- Adds .NET tests (`dotnet test --filter "TestCategory!=Integration"`) to the release workflow
- Steps run after the frontend build and before the publish step, so a failing test blocks the release

Closes #145