### PR TITLE
tests: add unit tests for InputManager and KeyboardInputProvider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,15 @@ Avoid: niche libraries, multiple libraries solving the same problem, dependencie
 - Throw domain-specific exceptions inheriting from `PhotoBoothException`
 - Tests use MSTest with descriptive method names
 
+## Test Classification
+
+CI runs `dotnet test --filter "TestCategory!=Integration"`, so every new test class **must** be correctly classified:
+
+- **Unit tests** (no attribute): Pure in-process tests using fakes/mocks. These run in CI.
+- **Integration tests** (`[TestCategory("Integration")]`): Tests that require external hardware (camera, Android device via ADB), a real OS-level resource unavailable in CI (e.g. `Console.KeyAvailable` loop with real input), or long-running real-world scenarios. These are skipped in CI.
+
+When writing a new test class, explicitly decide which category it belongs to and apply `[TestCategory("Integration")]` when appropriate. Do not add the attribute to tests that are actually unit tests just because they touch Infrastructure code.
+
 ## Camera Provider Configuration
 
 The application supports camera providers configured via `Camera:Provider` in appsettings.json. Provider-specific settings are in subsections (`Camera:OpenCv`, `Camera:Android`), each with their own `CaptureLatencyMs`.

--- a/tests/PhotoBooth.Infrastructure.Tests/Input/FakeCaptureWorkflowService.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Input/FakeCaptureWorkflowService.cs
@@ -1,0 +1,27 @@
+using PhotoBooth.Application.Services;
+
+namespace PhotoBooth.Infrastructure.Tests.Input;
+
+internal sealed class FakeCaptureWorkflowService : ICaptureWorkflowService
+{
+    private readonly SemaphoreSlim _triggerSignal = new(0);
+
+    public List<string> TriggerSources { get; } = [];
+    public Exception? ThrowOnTrigger { get; set; }
+    public int CountdownDurationMs => 0;
+
+    public Task TriggerCaptureAsync(string triggerSource, int? durationOverrideMs = null, CancellationToken cancellationToken = default)
+    {
+        if (ThrowOnTrigger != null)
+            throw ThrowOnTrigger;
+
+        TriggerSources.Add(triggerSource);
+        _triggerSignal.Release();
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> WaitForTriggerAsync(TimeSpan timeout)
+    {
+        return await _triggerSignal.WaitAsync(timeout);
+    }
+}

--- a/tests/PhotoBooth.Infrastructure.Tests/Input/FakeInputProvider.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Input/FakeInputProvider.cs
@@ -1,0 +1,56 @@
+using PhotoBooth.Domain.Interfaces;
+
+namespace PhotoBooth.Infrastructure.Tests.Input;
+
+internal sealed class FakeInputProvider : IInputProvider
+{
+    private readonly SemaphoreSlim _startSignal = new(0);
+    private readonly SemaphoreSlim _stopSignal = new(0);
+
+    public string Name { get; }
+    public bool StartCalled { get; private set; }
+    public bool StopCalled { get; private set; }
+    public Exception? ThrowOnStart { get; set; }
+    public Exception? ThrowOnStop { get; set; }
+
+    public bool HasSubscribers => CaptureTriggered != null;
+
+    public event EventHandler<CaptureTriggeredEventArgs>? CaptureTriggered;
+
+    public FakeInputProvider(string name = "fake")
+    {
+        Name = name;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        StartCalled = true;
+        _startSignal.Release();
+        if (ThrowOnStart != null)
+            throw ThrowOnStart;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        StopCalled = true;
+        _stopSignal.Release();
+        if (ThrowOnStop != null)
+            throw ThrowOnStop;
+        return Task.CompletedTask;
+    }
+
+    public void FireCaptureTriggered()
+    {
+        CaptureTriggered?.Invoke(this, new CaptureTriggeredEventArgs { Source = Name });
+    }
+
+    /// <summary>
+    /// Waits until StartAsync has been called by the InputManager's ExecuteAsync loop.
+    /// Since the event subscription happens before StartAsync, this also guarantees
+    /// that CaptureTriggered is wired up.
+    /// </summary>
+    public Task<bool> WaitForStartAsync(TimeSpan timeout) => _startSignal.WaitAsync(timeout);
+
+    public Task<bool> WaitForStopAsync(TimeSpan timeout) => _stopSignal.WaitAsync(timeout);
+}

--- a/tests/PhotoBooth.Infrastructure.Tests/Input/InputManagerTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Input/InputManagerTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using PhotoBooth.Infrastructure.Input;
+
+namespace PhotoBooth.Infrastructure.Tests.Input;
+
+[TestClass]
+public class InputManagerTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    [TestMethod]
+    public async Task TriggerCaptureAsync_CalledWithCorrectSource_WhenProviderFiresTrigger()
+    {
+        var provider = new FakeInputProvider("test-source");
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([provider], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await provider.WaitForStartAsync(Timeout);
+
+        provider.FireCaptureTriggered();
+        var triggered = await workflow.WaitForTriggerAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(triggered, "Capture should have been triggered");
+        Assert.HasCount(1, workflow.TriggerSources);
+        Assert.AreEqual("test-source", workflow.TriggerSources[0]);
+    }
+
+    [TestMethod]
+    public async Task StartsAndStopsCleanly_WhenNoInputProviders()
+    {
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsEmpty(workflow.TriggerSources);
+    }
+
+    [TestMethod]
+    public async Task ProvidersStoppedAndUnsubscribed_WhenServiceStopped()
+    {
+        var provider1 = new FakeInputProvider("p1");
+        var provider2 = new FakeInputProvider("p2");
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([provider1, provider2], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await provider1.WaitForStartAsync(Timeout);
+        await provider2.WaitForStartAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(provider1.StopCalled, "Provider1 should have been stopped");
+        Assert.IsTrue(provider2.StopCalled, "Provider2 should have been stopped");
+        Assert.IsFalse(provider1.HasSubscribers, "Provider1 event should be unsubscribed");
+        Assert.IsFalse(provider2.HasSubscribers, "Provider2 event should be unsubscribed");
+
+        // Firing after stop should not trigger the workflow
+        provider1.FireCaptureTriggered();
+        await Task.Delay(100);
+        Assert.IsEmpty(workflow.TriggerSources);
+    }
+
+    [TestMethod]
+    public async Task OtherProvidersStillStarted_WhenOneProviderStartAsyncThrows()
+    {
+        var failingProvider = new FakeInputProvider("failing")
+        {
+            ThrowOnStart = new InvalidOperationException("start failed")
+        };
+        var workingProvider = new FakeInputProvider("working");
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([failingProvider, workingProvider], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await failingProvider.WaitForStartAsync(Timeout);
+        await workingProvider.WaitForStartAsync(Timeout);
+
+        Assert.IsTrue(failingProvider.StartCalled, "Failing provider should have been attempted");
+        Assert.IsTrue(workingProvider.StartCalled, "Working provider should still have been started");
+
+        workingProvider.FireCaptureTriggered();
+        var triggered = await workflow.WaitForTriggerAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(triggered, "Working provider should still be able to trigger captures");
+    }
+
+    [TestMethod]
+    public async Task OtherProvidersStillStopped_WhenOneProviderStopAsyncThrows()
+    {
+        var failingProvider = new FakeInputProvider("failing")
+        {
+            ThrowOnStop = new InvalidOperationException("stop failed")
+        };
+        var workingProvider = new FakeInputProvider("working");
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([failingProvider, workingProvider], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await failingProvider.WaitForStartAsync(Timeout);
+        await workingProvider.WaitForStartAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(failingProvider.StopCalled, "Failing provider stop should have been attempted");
+        Assert.IsTrue(workingProvider.StopCalled, "Working provider should still have been stopped");
+    }
+
+    [TestMethod]
+    public async Task ExceptionLoggedNotRethrown_WhenTriggerCaptureAsyncThrows()
+    {
+        var provider = new FakeInputProvider("p1");
+        var workflow = new FakeCaptureWorkflowService
+        {
+            ThrowOnTrigger = new InvalidOperationException("workflow blew up")
+        };
+        var manager = new InputManager([provider], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await provider.WaitForStartAsync(Timeout);
+
+        // Fire once with the failing workflow — should not crash the service
+        provider.FireCaptureTriggered();
+        await Task.Delay(200);
+
+        // Service should still be alive; now allow successful triggers
+        workflow.ThrowOnTrigger = null;
+        provider.FireCaptureTriggered();
+        var triggered = await workflow.WaitForTriggerAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.IsTrue(triggered, "Service should continue functioning after a swallowed exception");
+    }
+
+    [TestMethod]
+    public async Task AllProvidersCanTriggerCaptures_WhenMultipleProviders()
+    {
+        var provider1 = new FakeInputProvider("source-a");
+        var provider2 = new FakeInputProvider("source-b");
+        var workflow = new FakeCaptureWorkflowService();
+        var manager = new InputManager([provider1, provider2], workflow, NullLogger<InputManager>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await manager.StartAsync(cts.Token);
+        await provider1.WaitForStartAsync(Timeout);
+        await provider2.WaitForStartAsync(Timeout);
+
+        provider1.FireCaptureTriggered();
+        await workflow.WaitForTriggerAsync(Timeout);
+
+        provider2.FireCaptureTriggered();
+        await workflow.WaitForTriggerAsync(Timeout);
+
+        await manager.StopAsync(CancellationToken.None);
+
+        Assert.HasCount(2, workflow.TriggerSources);
+        CollectionAssert.Contains(workflow.TriggerSources, "source-a");
+        CollectionAssert.Contains(workflow.TriggerSources, "source-b");
+    }
+}

--- a/tests/PhotoBooth.Infrastructure.Tests/Input/KeyboardInputProviderTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Input/KeyboardInputProviderTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using PhotoBooth.Infrastructure.Input;
+
+namespace PhotoBooth.Infrastructure.Tests.Input;
+
+[TestClass]
+public class KeyboardInputProviderTests
+{
+    [TestMethod]
+    public void Name_ReturnsKeyboard()
+    {
+        var provider = new KeyboardInputProvider(NullLogger<KeyboardInputProvider>.Instance);
+
+        Assert.AreEqual("keyboard", provider.Name);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_CompletesWithoutError_WhenConsoleUnavailable()
+    {
+        // In test/CI environments Console.KeyAvailable throws, so StartAsync returns early.
+        var provider = new KeyboardInputProvider(NullLogger<KeyboardInputProvider>.Instance);
+
+        await provider.StartAsync();
+        await provider.StopAsync();
+    }
+
+    [TestMethod]
+    public async Task StartAsync_CalledTwice_CompletesWithoutError()
+    {
+        var provider = new KeyboardInputProvider(NullLogger<KeyboardInputProvider>.Instance);
+
+        await provider.StartAsync();
+        await provider.StartAsync(); // second call should be a no-op
+        await provider.StopAsync();
+    }
+
+    [TestMethod]
+    public async Task StopAsync_CompletesCleanly_WhenNeverStarted()
+    {
+        var provider = new KeyboardInputProvider(NullLogger<KeyboardInputProvider>.Instance);
+
+        await provider.StopAsync();
+    }
+
+    [TestMethod]
+    public void Dispose_CompletesCleanly_WithoutStarting()
+    {
+        var provider = new KeyboardInputProvider(NullLogger<KeyboardInputProvider>.Instance);
+
+        provider.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 7 unit tests for `InputManager` covering: event routing to workflow, lifecycle with no providers, stop/unsubscribe behaviour, fault isolation when a provider start/stop throws, swallowed exceptions on workflow errors, and multi-provider triggering
- Adds 5 unit tests for `KeyboardInputProvider` covering all testable code paths (the console read loop is untestable in CI since `Console.KeyAvailable` is unavailable there)
- Introduces `FakeInputProvider` and `FakeCaptureWorkflowService` test doubles with semaphore-based synchronization to avoid race conditions inherent in `BackgroundService.ExecuteAsync` running in the background
- Adds a test classification rule to `CLAUDE.md` requiring all new test classes to be explicitly tagged `[TestCategory("Integration")]` when they require hardware or OS resources unavailable in CI

## Test plan

- [x] All 12 new tests pass locally
- [x] `dotnet build tests/PhotoBooth.Infrastructure.Tests/` — 0 warnings, 0 errors
- [x] `dotnet test tests/PhotoBooth.Infrastructure.Tests/` — 94 tests, all pass
- [ ] CI passes with `--filter "TestCategory!=Integration"` (new tests have no Integration tag)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)