### PR TITLE
tests: add PrepareAsync tracking to StubCameraProvider and verify workflow calls it

### DIFF
--- a/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
@@ -68,6 +68,22 @@ public sealed class CaptureWorkflowServiceTests
     }
 
     [TestMethod]
+    public async Task TriggerCaptureAsync_CallsPrepareAsync()
+    {
+        // Arrange
+        _cameraProvider.IsAvailable = true;
+
+        // Act
+        await _service.TriggerCaptureAsync("test");
+
+        // Wait for the background workflow to complete
+        await Task.Delay(1000);
+
+        // Assert
+        Assert.IsTrue(_cameraProvider.PrepareWasCalled);
+    }
+
+    [TestMethod]
     public async Task TriggerCaptureAsync_WhenCaptureFails_BroadcastsCaptureFailedEvent()
     {
         // Arrange

--- a/tests/PhotoBooth.Application.Tests/TestDoubles/StubCameraProvider.cs
+++ b/tests/PhotoBooth.Application.Tests/TestDoubles/StubCameraProvider.cs
@@ -7,9 +7,16 @@ public sealed class StubCameraProvider : ICameraProvider
     public bool IsAvailable { get; set; } = true;
     public byte[] ImageData { get; set; } = [1, 2, 3];
     public TimeSpan CaptureLatency { get; set; } = TimeSpan.Zero;
+    public bool PrepareWasCalled { get; private set; }
 
     public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(IsAvailable);
+
+    public Task PrepareAsync(CancellationToken cancellationToken = default)
+    {
+        PrepareWasCalled = true;
+        return Task.CompletedTask;
+    }
 
     public Task<byte[]> CaptureAsync(CancellationToken cancellationToken = default)
         => Task.FromResult(ImageData);


### PR DESCRIPTION
Adds  tracking to  and a new test asserting that  calls  before capturing.

Closes #140