### PR TITLE
docs: update git workflow to avoid commands requiring special approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ Always use GitHub Flow when working on issues:
 
 2. **Commit** changes with descriptive messages:
    - Write commit messages as plain double-quoted strings — no heredocs, no `$()` substitution
-   - For multi-line messages use separate `-m` flags: `git -C .claude/worktrees/6-enhance-look-and-feel commit -m "title" -m "body"`
+   - Each `-m` value must be a single line — newlines inside a `-m` string cause a "quoted characters in flag names" error
+   - For multi-line messages use separate `-m` flags, one per line: `git -C .claude/worktrees/6-enhance-look-and-feel commit -m "title" -m "body line"`
 
 3. **Push** the branch and **create a PR**:
    - Push using `-C`: `git -C .claude/worktrees/6-enhance-look-and-feel push -u origin 6-enhance-look-and-feel`
@@ -29,6 +30,7 @@ Always use GitHub Flow when working on issues:
    - PR title should be descriptive of the change
    - Reference the issue in the PR body with `Closes #<issue-number>` to auto-close on merge
    - Pass `--title` and `--body` as plain strings to `gh pr create` — no heredocs, no command substitution, and no backticks (backticks in strings trigger a command substitution approval prompt even when used as markdown formatting)
+   - Always pass `--head <branch-name> --base main` to `gh pr create` — without these, `gh` picks up the main repo context and fails with "head branch is the same as base branch"
 
 4. **Merge** after review (squash merge preferred for clean history)
 


### PR DESCRIPTION
Updates the Git Workflow section of CLAUDE.md to eliminate friction from security approval prompts.

**Changes:**
- Use git -C instead of cd && git for worktree commands (compound cd + git triggers bare repository attack approval)
- Add guidance to use full worktree paths for all file reads/edits/writes
- Avoid backticks in gh pr create strings (triggers command substitution approval even as markdown formatting)
- Fix cleanup step: use git -C repo-root for all commands; skip git checkout main since it is already checked out in the primary worktree and will fail with 'already used by worktree' error
- Require worktree to be created before any file edits

Closes #153