### PR TITLE
tests: add page-level tests for BoothPage, DownloadPage, PhotoDetailPage

### DIFF
--- a/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { BoothPage } from '../BoothPage';
+import type { PhotoBoothEvent } from '../../api/types';
+
+let capturedOnEvent: ((event: PhotoBoothEvent) => void) | null = null;
+
+vi.mock('../../api/events', () => ({
+  useEventStream: (handler: (event: PhotoBoothEvent) => void) => {
+    capturedOnEvent = handler;
+  },
+}));
+
+const mockTriggerCapture = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  triggerCapture: (...args: unknown[]) => mockTriggerCapture(...(args as [])),
+}));
+
+vi.mock('../../hooks/useSlideshowNavigation', () => ({
+  useSlideshowNavigation: () => ({
+    currentPhoto: null,
+    goNext: vi.fn(),
+    goPrevious: vi.fn(),
+    skip: vi.fn(),
+    toggleMode: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    currentIndex: 0,
+    totalPhotos: 0,
+    isRandom: false,
+  }),
+}));
+
+vi.mock('../../hooks/useKeyboardNavigation', () => ({
+  useKeyboardNavigation: () => {},
+}));
+
+vi.mock('../../hooks/useGamepadNavigation', () => ({
+  useGamepadNavigation: () => {},
+}));
+
+vi.mock('../../components/Slideshow', () => ({
+  Slideshow: () => <div data-testid="slideshow" />,
+}));
+
+vi.mock('../../components/CaptureOverlay', () => ({
+  CaptureOverlay: ({ durationMs }: { durationMs: number }) => (
+    <div data-testid="capture-overlay" data-duration={durationMs} />
+  ),
+}));
+
+vi.mock('../../components/PhotoDisplay', () => ({
+  PhotoDisplay: ({ code }: { code: string }) => (
+    <div data-testid="photo-display" data-code={code} />
+  ),
+}));
+
+const countdownEvent = (durationMs = 3000): PhotoBoothEvent => ({
+  eventType: 'countdown-started',
+  durationMs,
+  triggerSource: 'api',
+  timestamp: '2025-01-01T00:00:00Z',
+});
+
+const photoCapturedEvent = (): PhotoBoothEvent => ({
+  eventType: 'photo-captured',
+  photoId: 'photo-1',
+  code: '42',
+  imageUrl: '/api/photos/photo-1/image',
+  timestamp: '2025-01-01T00:00:00Z',
+});
+
+const captureFailedEvent = (error = 'Camera error'): PhotoBoothEvent => ({
+  eventType: 'capture-failed',
+  error,
+  timestamp: '2025-01-01T00:00:00Z',
+});
+
+describe('BoothPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    mockTriggerCapture.mockResolvedValue({ message: 'ok', countdownDurationMs: 3000 });
+    capturedOnEvent = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders slideshow when no captured photo', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    expect(screen.getByTestId('slideshow')).toBeInTheDocument();
+  });
+
+  it('does not render CaptureOverlay initially', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
+  });
+
+  it('calls triggerCapture when page is clicked', async () => {
+    const { container } = render(<BoothPage watchdogTimeoutMs={60000} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('.booth-page')!);
+    });
+    expect(mockTriggerCapture).toHaveBeenCalledOnce();
+  });
+
+  it('shows error message when triggerCapture rejects', async () => {
+    mockTriggerCapture.mockRejectedValue(new Error('Network error'));
+    const { container } = render(<BoothPage watchdogTimeoutMs={60000} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('.booth-page')!);
+    });
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('clears error message after 3000ms', async () => {
+    mockTriggerCapture.mockRejectedValue(new Error('Network error'));
+    const { container } = render(<BoothPage watchdogTimeoutMs={60000} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('.booth-page')!);
+    });
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(3000); });
+    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+  });
+
+  it('shows CaptureOverlay when countdown-started event arrives', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    expect(screen.getByTestId('capture-overlay')).toBeInTheDocument();
+  });
+
+  it('shows PhotoDisplay when photo-captured event arrives', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    act(() => { capturedOnEvent!(photoCapturedEvent()); });
+    expect(screen.getByTestId('photo-display')).toBeInTheDocument();
+  });
+
+  it('hides CaptureOverlay after photo is captured', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    expect(screen.getByTestId('capture-overlay')).toBeInTheDocument();
+    act(() => { capturedOnEvent!(photoCapturedEvent()); });
+    expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
+  });
+
+  it('shows error message on capture-failed event', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    act(() => { capturedOnEvent!(captureFailedEvent('Camera error')); });
+    expect(screen.getByText('Camera error')).toBeInTheDocument();
+  });
+
+  it('hides CaptureOverlay after capture fails', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    expect(screen.getByTestId('capture-overlay')).toBeInTheDocument();
+    act(() => { capturedOnEvent!(captureFailedEvent()); });
+    expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
+  });
+
+  it('calls window.location.reload after watchdog timeout', () => {
+    const reloadMock = vi.fn();
+    vi.stubGlobal('location', { reload: reloadMock });
+    render(<BoothPage watchdogTimeoutMs={1000} />);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(reloadMock).toHaveBeenCalled();
+  });
+});

--- a/src/PhotoBooth.Web/src/pages/__tests__/DownloadPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/DownloadPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { DownloadPage } from '../DownloadPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../components/PhotoGrid', () => ({
+  PhotoGrid: ({ onPhotoClick }: { onPhotoClick: (code: string) => void }) => (
+    <div data-testid="photo-grid" onClick={() => onPhotoClick('42')} />
+  ),
+}));
+
+describe('DownloadPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    // Reset URL so language state doesn't leak between tests
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders search input with placeholder text', () => {
+    render(<DownloadPage />);
+    expect(screen.getByPlaceholderText('Photo code')).toBeInTheDocument();
+  });
+
+  it('submit button is disabled when input is empty', () => {
+    render(<DownloadPage />);
+    expect(screen.getByRole('button', { name: 'Find Photo' })).toBeDisabled();
+  });
+
+  it('enables submit button when code is entered', () => {
+    render(<DownloadPage />);
+    fireEvent.change(screen.getByPlaceholderText('Photo code'), { target: { value: '42' } });
+    expect(screen.getByRole('button', { name: 'Find Photo' })).not.toBeDisabled();
+  });
+
+  it('navigates to /photo/{code} on form submit', () => {
+    render(<DownloadPage />);
+    const input = screen.getByPlaceholderText('Photo code');
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/photo/42');
+  });
+
+  it('trims whitespace from code before navigating', () => {
+    render(<DownloadPage />);
+    const input = screen.getByPlaceholderText('Photo code');
+    fireEvent.change(input, { target: { value: '  42  ' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(mockNavigate).toHaveBeenCalledWith('/photo/42');
+  });
+
+  it('does not navigate when code is only whitespace', () => {
+    render(<DownloadPage />);
+    const input = screen.getByPlaceholderText('Photo code');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('renders PhotoGrid component', () => {
+    render(<DownloadPage />);
+    expect(screen.getByTestId('photo-grid')).toBeInTheDocument();
+  });
+
+  it('navigates to /photo/{code} when PhotoGrid onPhotoClick fires', () => {
+    render(<DownloadPage />);
+    fireEvent.click(screen.getByTestId('photo-grid'));
+    expect(mockNavigate).toHaveBeenCalledWith('/photo/42');
+  });
+
+  it('language toggle switches active class', () => {
+    render(<DownloadPage />);
+    const englishBtn = screen.getByRole('button', { name: 'English' });
+    const spanishBtn = screen.getByRole('button', { name: 'Español' });
+
+    // English should be active initially (jsdom navigator.language defaults to 'en')
+    expect(englishBtn).toHaveClass('active');
+    expect(spanishBtn).not.toHaveClass('active');
+
+    fireEvent.click(spanishBtn);
+    expect(spanishBtn).toHaveClass('active');
+    expect(englishBtn).not.toHaveClass('active');
+  });
+});

--- a/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
+import { PhotoDetailPage } from '../PhotoDetailPage';
+import type { PhotoDto } from '../../api/types';
+
+const mockNavigate = vi.fn();
+const mockUseParams = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => mockUseParams(),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockGetPhotoByCode = vi.fn<(code: string) => Promise<PhotoDto | null>>();
+const mockGetAllPhotos = vi.fn<() => Promise<PhotoDto[]>>();
+
+vi.mock('../../api/client', () => ({
+  getPhotoByCode: (code: string) => mockGetPhotoByCode(code),
+  getPhotoImageUrl: (photoId: string, width?: number) => {
+    const base = `/api/photos/${photoId}/image`;
+    return width !== undefined ? `${base}?width=${width}` : base;
+  },
+  getAllPhotos: () => mockGetAllPhotos(),
+}));
+
+vi.mock('../../hooks/useSwipeNavigation', () => ({
+  useSwipeNavigation: () => {},
+}));
+
+vi.mock('../../i18n/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        loading: 'Loading...',
+        photoNotFoundError: 'Photo not found',
+        backToGallery: 'Back to Gallery',
+        getPhoto: 'Get Photo',
+        downloadPhoto: 'Download Photo',
+        sharePhoto: 'Share Photo',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+const mockPhoto: PhotoDto = {
+  id: 'photo-abc',
+  code: '42',
+  capturedAt: '2025-01-01T00:00:00Z',
+};
+
+describe('PhotoDetailPage', () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ code: '42' });
+    mockNavigate.mockClear();
+    mockGetPhotoByCode.mockResolvedValue(mockPhoto);
+    mockGetAllPhotos.mockResolvedValue([mockPhoto]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows loading indicator while photo is being fetched', () => {
+    mockGetPhotoByCode.mockReturnValue(new Promise(() => {}));
+    mockGetAllPhotos.mockReturnValue(new Promise(() => {}));
+    render(<PhotoDetailPage />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows error when no code parameter is provided', () => {
+    mockUseParams.mockReturnValue({ code: undefined });
+    render(<PhotoDetailPage />);
+    expect(screen.getByText('Photo not found')).toBeInTheDocument();
+  });
+
+  it('shows error when photo not found', async () => {
+    mockGetPhotoByCode.mockResolvedValue(null);
+    render(<PhotoDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Photo not found')).toBeInTheDocument();
+    });
+  });
+
+  it('renders photo image with correct src on success', async () => {
+    render(<PhotoDetailPage />);
+    await waitFor(() => {
+      const img = screen.getByRole('img');
+      expect(img).toHaveAttribute('src', '/api/photos/photo-abc/image?width=1200');
+    });
+  });
+
+  it('displays the photo code in nav bar', async () => {
+    render(<PhotoDetailPage />);
+    await waitFor(() => {
+      const codeEl = document.querySelector('.photo-detail-code');
+      expect(codeEl).toHaveTextContent('42');
+    });
+  });
+
+  it('navigates to /download when back button is clicked', async () => {
+    render(<PhotoDetailPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Gallery' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/download');
+  });
+
+  it('shows speed dial trigger button', async () => {
+    render(<PhotoDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Get Photo' })).toBeInTheDocument();
+    });
+  });
+
+  it('expands speed dial after fetching blob on trigger click', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['image data'], { type: 'image/jpeg' })),
+    } as Response));
+
+    render(<PhotoDetailPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Get Photo' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Download Photo' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows download button when expanded', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['image data'], { type: 'image/jpeg' })),
+    } as Response));
+
+    render(<PhotoDetailPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Get Photo' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Download Photo' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows share button when navigator.canShare is true', async () => {
+    Object.defineProperty(navigator, 'canShare', {
+      value: () => true,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['image data'], { type: 'image/jpeg' })),
+    } as Response));
+
+    render(<PhotoDetailPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Get Photo' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Share Photo' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides share button when navigator.canShare is false', async () => {
+    Object.defineProperty(navigator, 'canShare', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['image data'], { type: 'image/jpeg' })),
+    } as Response));
+
+    render(<PhotoDetailPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Get Photo' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Download Photo' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Share Photo' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 30 new unit tests across three new test files covering the main page components
- DownloadPage (9 tests): search input, submit button state, navigation, whitespace trimming, PhotoGrid integration, language toggle
- PhotoDetailPage (11 tests): loading state, error states, image rendering, nav bar, back button, speed dial expand/download/share
- BoothPage (11 tests): slideshow rendering, click-to-trigger, error display with clearance, SSE events (countdown/captured/failed), watchdog reload

## Key mocking decisions

- BoothPage: captures the `useEventStream` handler to simulate SSE events; uses fake timers for error clearance (3000ms) and watchdog timeout; stubs `Slideshow`, `CaptureOverlay`, `PhotoDisplay`
- PhotoDetailPage: mocks `useTranslation` to avoid URL/navigator side effects; stubs `fetch` for blob download flow; uses `Object.defineProperty` for `navigator.canShare`
- DownloadPage: stubs `PhotoGrid` to expose `onPhotoClick`; uses real `useTranslation` with URL reset between tests to prevent language state leakage

## Test plan

- [x] All 124 tests pass (`pnpm test`)
- [x] Existing tests unaffected
- [x] `vi.stubGlobal('location', ...)` used for watchdog test (jsdom 28 does not allow `vi.spyOn` on `window.location.reload`)

Closes #142