### PR TITLE
fix: add slideshowIntervalMs to useEffect dependency array in Slideshow.tsx

### DIFF
--- a/src/PhotoBooth.Web/src/components/Slideshow.tsx
+++ b/src/PhotoBooth.Web/src/components/Slideshow.tsx
@@ -105,7 +105,7 @@ export function Slideshow({ photo, qrCodeBaseUrl, swirlEffect = true, slideshowI
         key: photoKeyRef.current,
       };
     });
-  }, [photo]);
+  }, [photo, slideshowIntervalMs]);
 
   if (!photo || !currentState) {
     return <div className="slideshow-empty">{t('noPhotosToShow')}</div>;


### PR DESCRIPTION
Adds the missing slideshowIntervalMs dependency to the useEffect in Slideshow.tsx, fixing the ESLint warning in release builds.

Closes #157