### PR TITLE
fix: stop leaking exception messages via SSE CaptureFailedEvent

### DIFF
--- a/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
+++ b/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
@@ -124,7 +124,7 @@ public class CaptureWorkflowService : ICaptureWorkflowService
         {
             _logger.LogError(ex, "Capture failed");
             await _eventBroadcaster.BroadcastAsync(
-                new CaptureFailedEvent(ex.Message),
+                new CaptureFailedEvent("Photo capture failed"),
                 CancellationToken.None);
         }
     }

--- a/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
@@ -102,6 +102,6 @@ public sealed class CaptureWorkflowServiceTests
 
         var failedEvent = _eventBroadcaster.BroadcastedEvents[1] as CaptureFailedEvent;
         Assert.IsNotNull(failedEvent);
-        Assert.AreEqual("Test failure", failedEvent.Error);
+        Assert.AreEqual("Photo capture failed", failedEvent.Error);
     }
 }


### PR DESCRIPTION
When photo capture fails, the exception message was broadcast to all SSE clients via CaptureFailedEvent. Since /api/events is accessible to any network client, guests on the download page could see internal details such as file paths, library errors, and config values.

This replaces ex.Message with the generic string 'Photo capture failed'. The exception is already logged server-side, so no diagnostics are lost. The timeout path already used a safe static string - this aligns the exception catch path with the same approach.

Closes #123