### PR TITLE
feat: restrict /api/photos/capture to localhost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,8 @@ Example Android configuration:
 | `RateLimiting:WindowSeconds` | Rate limit window duration in seconds | `10` |
 | `Thumbnails:JpegQuality` | JPEG quality (0-100) for server-side resized thumbnails | `80` |
 | `Booth:RestrictToLocalhost` | Redirect non-localhost users from `/` to `/download` | `true` |
+| `Trigger:RestrictToLocalhost` | Restrict `/api/photos/trigger` to localhost only | `true` |
+| `Capture:RestrictToLocalhost` | Restrict `/api/photos/capture` to localhost only | `true` |
 
 ## Security
 

--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -6,7 +6,7 @@ namespace PhotoBooth.Server.Endpoints;
 
 public static class PhotoEndpoints
 {
-    public static void MapPhotoEndpoints(this IEndpointRouteBuilder app, IEndpointFilter? triggerFilter = null)
+    public static void MapPhotoEndpoints(this IEndpointRouteBuilder app, IEndpointFilter? triggerFilter = null, IEndpointFilter? captureFilter = null)
     {
         var group = app.MapGroup("/api/photos");
 
@@ -19,9 +19,14 @@ public static class PhotoEndpoints
             triggerEndpoint.AddEndpointFilter(triggerFilter);
         }
 
-        group.MapPost("/capture", CapturePhoto)
+        var captureEndpoint = group.MapPost("/capture", CapturePhoto)
             .WithName("CapturePhoto")
             .RequireRateLimiting("capture");
+
+        if (captureFilter is not null)
+        {
+            captureEndpoint.AddEndpointFilter(captureFilter);
+        }
 
         group.MapGet("/", GetAllPhotos)
             .WithName("GetAllPhotos");

--- a/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
+++ b/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
@@ -5,11 +5,13 @@ namespace PhotoBooth.Server.Filters;
 public class LocalhostOnlyFilter : IEndpointFilter
 {
     private readonly bool _enabled;
+    private readonly string _endpointName;
     private readonly ILogger<LocalhostOnlyFilter> _logger;
 
-    public LocalhostOnlyFilter(bool enabled, ILogger<LocalhostOnlyFilter> logger)
+    public LocalhostOnlyFilter(bool enabled, string endpointName, ILogger<LocalhostOnlyFilter> logger)
     {
         _enabled = enabled;
+        _endpointName = endpointName;
         _logger = logger;
     }
 
@@ -24,7 +26,7 @@ public class LocalhostOnlyFilter : IEndpointFilter
 
         if (!IsLocalhost(remoteIp))
         {
-            _logger.LogWarning("Blocked trigger request from non-localhost IP: {RemoteIp}", remoteIp);
+            _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}", _endpointName, remoteIp);
             return Results.Forbid();
         }
 

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -205,12 +205,20 @@ app.UseStaticFiles();
 
 // Create localhost-only filter for trigger endpoint
 var restrictTriggerToLocalhost = builder.Configuration.GetValue<bool?>("Trigger:RestrictToLocalhost") ?? true;
-var localhostFilter = new LocalhostOnlyFilter(
+var triggerLocalhostFilter = new LocalhostOnlyFilter(
     restrictTriggerToLocalhost,
+    "trigger",
+    app.Services.GetRequiredService<ILogger<LocalhostOnlyFilter>>());
+
+// Create localhost-only filter for capture endpoint
+var restrictCaptureToLocalhost = builder.Configuration.GetValue<bool?>("Capture:RestrictToLocalhost") ?? true;
+var captureLocalhostFilter = new LocalhostOnlyFilter(
+    restrictCaptureToLocalhost,
+    "capture",
     app.Services.GetRequiredService<ILogger<LocalhostOnlyFilter>>());
 
 // Map endpoints
-app.MapPhotoEndpoints(localhostFilter);
+app.MapPhotoEndpoints(triggerLocalhostFilter, captureLocalhostFilter);
 app.MapSlideshowEndpoints();
 app.MapCameraEndpoints();
 app.MapEventsEndpoints();

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -74,7 +74,9 @@
     // Hard timeout buffer in ms for high-latency cameras (e.g. Android over ADB)
     "BufferTimeoutHighLatencyMs": 45000,
     // Hard timeout buffer in ms for low-latency cameras (e.g. OpenCV)
-    "BufferTimeoutLowLatencyMs": 12000
+    "BufferTimeoutLowLatencyMs": 12000,
+    // Restrict /api/photos/capture to localhost only
+    "RestrictToLocalhost": true
   },
 
   // Keyboard/GPIO input settings

--- a/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
+++ b/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
@@ -20,7 +20,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenDisabled_AllowsAllRequests()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: false, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: false, "test", _logger);
         var context = CreateContext(IPAddress.Parse("192.168.1.100"));
         var nextCalled = false;
 
@@ -39,7 +39,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_AllowsIPv4Localhost()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(IPAddress.Loopback); // 127.0.0.1
         var nextCalled = false;
 
@@ -58,7 +58,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_AllowsIPv6Localhost()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(IPAddress.IPv6Loopback); // ::1
         var nextCalled = false;
 
@@ -77,7 +77,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_AllowsIPv4MappedLoopback()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(IPAddress.Loopback.MapToIPv6()); // ::ffff:127.0.0.1
         var nextCalled = false;
 
@@ -96,7 +96,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_BlocksExternalIPv4()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(IPAddress.Parse("192.168.1.100"));
         var nextCalled = false;
 
@@ -116,7 +116,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_BlocksExternalIPv6()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(IPAddress.Parse("2001:db8::1"));
         var nextCalled = false;
 
@@ -135,7 +135,7 @@ public sealed class LocalhostOnlyFilterTests
     public async Task InvokeAsync_WhenEnabled_BlocksNullIP()
     {
         // Arrange
-        var filter = new LocalhostOnlyFilter(enabled: true, _logger);
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
         var context = CreateContext(null);
         var nextCalled = false;
 


### PR DESCRIPTION
Applies the same LocalhostOnlyFilter pattern used by the trigger endpoint to the capture endpoint.

## Changes

- Add endpointName parameter to LocalhostOnlyFilter for clearer log messages
- Add captureFilter parameter to MapPhotoEndpoints and apply it to the /capture endpoint
- Read Capture:RestrictToLocalhost config (default true) in Program.cs and create a capture filter
- Add Capture:RestrictToLocalhost to appsettings.json (default true)
- Update LocalhostOnlyFilterTests to pass the new endpointName argument
- Document Trigger:RestrictToLocalhost and Capture:RestrictToLocalhost in CLAUDE.md

Closes #122