### PR TITLE
feat: add global exception handler middleware

### DIFF
--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -186,6 +186,24 @@ else
     app.UseHttpsRedirection();
 }
 
+// Global exception handler — must be early in the pipeline to catch all downstream exceptions
+app.UseExceptionHandler(exceptionApp =>
+{
+    exceptionApp.Run(async context =>
+    {
+        var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+        var exceptionFeature = context.Features.Get<Microsoft.AspNetCore.Diagnostics.IExceptionHandlerFeature>();
+        if (exceptionFeature != null)
+        {
+            logger.LogError(exceptionFeature.Error, "Unhandled exception");
+        }
+
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsJsonAsync(new { title = "An unexpected error occurred", status = 500 });
+    });
+});
+
 // Security headers (before static files so headers apply to all responses)
 app.UseSecurityHeaders();
 

--- a/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using PhotoBooth.Application.DTOs;
@@ -302,6 +303,10 @@ public sealed class PhotoEndpointsTests
 
         // Assert
         Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.AreEqual("application/json", response.Content.Headers.ContentType?.MediaType);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.AreEqual("An unexpected error occurred", body.GetProperty("title").GetString());
+        Assert.AreEqual(500, body.GetProperty("status").GetInt32());
     }
 }
 


### PR DESCRIPTION
Adds UseExceptionHandler in Program.cs to catch all unhandled exceptions, log them at Error level, and return a consistent JSON 500 response body instead of letting ASP.NET Core's default handler expose stack traces or return an empty body.

Also updates the existing test to verify the structured response body and Content-Type header.

Closes #125