### PR TITLE
feat: add upper-bound validation on durationMs trigger parameter

### DIFF
--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -33,11 +33,18 @@ public static class PhotoEndpoints
             .WithName("GetPhotoImage");
     }
 
+    private const int MaxDurationMs = 60_000;
+
     private static async Task<IResult> TriggerCapture(
         ICaptureWorkflowService workflowService,
         int? durationMs,
         CancellationToken cancellationToken)
     {
+        if (durationMs.HasValue && (durationMs.Value <= 0 || durationMs.Value > MaxDurationMs))
+        {
+            return Results.BadRequest($"durationMs must be between 1 and {MaxDurationMs}.");
+        }
+
         var effectiveDuration = durationMs ?? workflowService.CountdownDurationMs;
         await workflowService.TriggerCaptureAsync("web-ui", durationMs, cancellationToken);
 

--- a/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
+++ b/tests/PhotoBooth.Server.Tests/PhotoEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using PhotoBooth.Application.DTOs;
 using PhotoBooth.Application.Services;
@@ -23,6 +24,13 @@ public sealed class PhotoEndpointsTests
         _factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Trigger:RestrictToLocalhost"] = "false"
+                    });
+                });
                 builder.ConfigureServices(services =>
                 {
                     // Remove existing registrations
@@ -266,6 +274,36 @@ public sealed class PhotoEndpointsTests
         Assert.IsNotNull(page);
         Assert.HasCount(2, page.Photos);
         Assert.IsNull(page.NextCursor);
+    }
+
+    [TestMethod]
+    public async Task TriggerCapture_WhenDurationMsExceedsMax_ReturnsBadRequest()
+    {
+        // Act
+        var response = await _client.PostAsync("/api/photos/trigger?durationMs=60001", null);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task TriggerCapture_WhenDurationMsIsNegative_ReturnsBadRequest()
+    {
+        // Act
+        var response = await _client.PostAsync("/api/photos/trigger?durationMs=-1", null);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task TriggerCapture_WhenDurationMsIsZero_ReturnsBadRequest()
+    {
+        // Act
+        var response = await _client.PostAsync("/api/photos/trigger?durationMs=0", null);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [TestMethod]


### PR DESCRIPTION
Validates that the optional durationMs query parameter on POST /api/photos/trigger is within a safe range.

- Returns 400 Bad Request if durationMs <= 0 or durationMs > 60000
- null (omitted) remains valid and falls back to the configured default
- Defines MaxDurationMs = 60_000 as a named constant

Also sets Trigger:RestrictToLocalhost=false in the shared WebApplicationFactory configuration so the LocalhostOnlyFilter does not block in-memory test requests (the test server has a null remote IP, which the filter treats as non-localhost).

Closes #124