### PR TITLE
perf: remove unnecessary async from EventBroadcaster.BroadcastAsync

### DIFF
--- a/src/PhotoBooth.Infrastructure/Events/EventBroadcaster.cs
+++ b/src/PhotoBooth.Infrastructure/Events/EventBroadcaster.cs
@@ -15,7 +15,7 @@ public class EventBroadcaster : IEventBroadcaster
         _logger = logger;
     }
 
-    public async Task BroadcastAsync(PhotoBoothEvent evt, CancellationToken cancellationToken = default)
+    public Task BroadcastAsync(PhotoBoothEvent evt, CancellationToken cancellationToken = default)
     {
         List<Channel<PhotoBoothEvent>> subscribers;
         lock (_lock)
@@ -56,6 +56,8 @@ public class EventBroadcaster : IEventBroadcaster
                 }
             }
         }
+
+        return Task.CompletedTask;
     }
 
     public async IAsyncEnumerable<PhotoBoothEvent> SubscribeAsync(


### PR DESCRIPTION
The method only calls TryWrite on channels and never awaits anything, so the compiler was generating an async state machine with allocation and state tracking overhead on every event broadcast.

- Remove the async modifier from BroadcastAsync
- Add return Task.CompletedTask at the end

All callers await the returned Task, which works identically.

Closes #127