### PR TITLE
refactor: extract shared IsLocalhost into NetworkUtilities

### DIFF
--- a/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
+++ b/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using PhotoBooth.Server.Utilities;
 
 namespace PhotoBooth.Server.Filters;
 
@@ -24,34 +25,12 @@ public class LocalhostOnlyFilter : IEndpointFilter
 
         var remoteIp = context.HttpContext.Connection.RemoteIpAddress;
 
-        if (!IsLocalhost(remoteIp))
+        if (!NetworkUtilities.IsLocalhost(remoteIp))
         {
             _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}", _endpointName, remoteIp);
             return Results.Forbid();
         }
 
         return await next(context);
-    }
-
-    private static bool IsLocalhost(IPAddress? ipAddress)
-    {
-        if (ipAddress is null)
-        {
-            return false;
-        }
-
-        // Check for IPv4 loopback (127.0.0.1)
-        if (IPAddress.IsLoopback(ipAddress))
-        {
-            return true;
-        }
-
-        // Check for IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)
-        if (ipAddress.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(ipAddress.MapToIPv4()))
-        {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
@@ -1,4 +1,4 @@
-using System.Net;
+using PhotoBooth.Server.Utilities;
 
 namespace PhotoBooth.Server.Middleware;
 
@@ -15,7 +15,7 @@ public sealed class BoothRedirectMiddleware
 
     public Task InvokeAsync(HttpContext context)
     {
-        if (_enabled && IsRootPath(context.Request.Path) && !IsLocalhost(context.Connection.RemoteIpAddress))
+        if (_enabled && IsRootPath(context.Request.Path) && !NetworkUtilities.IsLocalhost(context.Connection.RemoteIpAddress))
         {
             context.Response.Redirect("/download", permanent: false);
             return Task.CompletedTask;
@@ -27,27 +27,5 @@ public sealed class BoothRedirectMiddleware
     private static bool IsRootPath(PathString path)
     {
         return !path.HasValue || path == "/";
-    }
-
-    private static bool IsLocalhost(IPAddress? ipAddress)
-    {
-        if (ipAddress is null)
-        {
-            return false;
-        }
-
-        // Check for IPv4 loopback (127.0.0.1) or IPv6 loopback (::1)
-        if (IPAddress.IsLoopback(ipAddress))
-        {
-            return true;
-        }
-
-        // Check for IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)
-        if (ipAddress.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(ipAddress.MapToIPv4()))
-        {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
+++ b/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
@@ -1,0 +1,28 @@
+using System.Net;
+
+namespace PhotoBooth.Server.Utilities;
+
+public static class NetworkUtilities
+{
+    public static bool IsLocalhost(IPAddress? ipAddress)
+    {
+        if (ipAddress is null)
+        {
+            return false;
+        }
+
+        // Check for IPv4 loopback (127.0.0.1) or IPv6 loopback (::1)
+        if (IPAddress.IsLoopback(ipAddress))
+        {
+            return true;
+        }
+
+        // Check for IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)
+        if (ipAddress.IsIPv4MappedToIPv6 && IPAddress.IsLoopback(ipAddress.MapToIPv4()))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
+++ b/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using PhotoBooth.Server.Utilities;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public sealed class NetworkUtilitiesTests
+{
+    [TestMethod]
+    public void IsLocalhost_WhenNull_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(null));
+    }
+
+    [TestMethod]
+    public void IsLocalhost_WhenIPv4Loopback_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(IPAddress.Parse("127.0.0.1")));
+    }
+
+    [TestMethod]
+    public void IsLocalhost_WhenIPv6Loopback_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(IPAddress.Parse("::1")));
+    }
+
+    [TestMethod]
+    public void IsLocalhost_WhenIPv4MappedIPv6Loopback_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(IPAddress.Parse("::ffff:127.0.0.1")));
+    }
+
+    [TestMethod]
+    public void IsLocalhost_WhenExternalIPv4_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(IPAddress.Parse("192.168.1.100")));
+    }
+
+    [TestMethod]
+    public void IsLocalhost_WhenExternalIPv6_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(IPAddress.Parse("2001:db8::1")));
+    }
+}


### PR DESCRIPTION
Consolidates the duplicated IsLocalhost(IPAddress?) logic from LocalhostOnlyFilter and BoothRedirectMiddleware into a single NetworkUtilities.IsLocalhost utility, so a bug fix in one place covers both callers.

## Changes

- New src/PhotoBooth.Server/Utilities/NetworkUtilities.cs with public static IsLocalhost(IPAddress?) method
- LocalhostOnlyFilter and BoothRedirectMiddleware updated to delegate to NetworkUtilities.IsLocalhost
- New NetworkUtilitiesTests.cs with 6 unit tests covering null, IPv4 loopback, IPv6 loopback, IPv4-mapped IPv6 loopback, external IPv4, and external IPv6

Closes #126