### PR TITLE
feat: add catch-all 404 page for unknown routes

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -538,3 +538,42 @@ body {
 .language-separator {
   color: #444;
 }
+
+/* Not Found Page */
+.not-found-page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  gap: 1rem;
+}
+
+.not-found-code {
+  font-size: 8rem;
+  font-weight: 700;
+  color: #666;
+  line-height: 1;
+}
+
+.not-found-message {
+  font-size: 1.25rem;
+  color: #fff;
+}
+
+.not-found-link {
+  margin-top: 0.5rem;
+  background: none;
+  border: none;
+  color: #3b82f6;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.not-found-link:hover {
+  text-decoration: underline;
+}

--- a/src/PhotoBooth.Web/src/App.tsx
+++ b/src/PhotoBooth.Web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { BoothPage } from './pages/BoothPage';
 import { DownloadPage } from './pages/DownloadPage';
 import { PhotoDetailPage } from './pages/PhotoDetailPage';
+import { NotFoundPage } from './pages/NotFoundPage';
 import { getClientConfig } from './api/client';
 import type { GamepadConfig } from './api/types';
 import './App.css';
@@ -37,6 +38,7 @@ function App() {
           <Route path="/" element={<BoothPage qrCodeBaseUrl={qrCodeBaseUrl} swirlEffect={swirlEffect} slideshowIntervalMs={slideshowIntervalMs} gamepadConfig={gamepadConfig} watchdogTimeoutMs={watchdogTimeoutMs} />} />
           <Route path="/download" element={<DownloadPage />} />
           <Route path="/photo/:code" element={<PhotoDetailPage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -24,6 +24,10 @@ export const translations = {
 
     // Slideshow
     noPhotosToShow: 'No photos to show yet',
+
+    // Not found page
+    pageNotFound: 'Page not found',
+    goToGallery: 'Go to Gallery',
   },
   es: {
     // Download page
@@ -50,6 +54,10 @@ export const translations = {
 
     // Slideshow
     noPhotosToShow: 'Aún no hay fotos para mostrar',
+
+    // Not found page
+    pageNotFound: 'Pagina no encontrada',
+    goToGallery: 'Ir a la Galeria',
   },
 } as const;
 

--- a/src/PhotoBooth.Web/src/pages/NotFoundPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from '../i18n/useTranslation';
+
+export function NotFoundPage() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return (
+    <div className="not-found-page">
+      <span className="not-found-code">404</span>
+      <p className="not-found-message">{t('pageNotFound')}</p>
+      <button className="not-found-link" onClick={() => navigate('/download')}>
+        {t('goToGallery')}
+      </button>
+    </div>
+  );
+}

--- a/src/PhotoBooth.Web/src/pages/__tests__/NotFoundPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { NotFoundPage } from '../NotFoundPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('NotFoundPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders 404 text', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('renders page not found message', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+  });
+
+  it('renders a button to go to the gallery', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByRole('button', { name: 'Go to Gallery' })).toBeInTheDocument();
+  });
+
+  it('navigates to /download when gallery button is clicked', () => {
+    render(<NotFoundPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Gallery' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/download');
+  });
+});


### PR DESCRIPTION
## Summary

- Add NotFoundPage component with 404 heading, translated message, and a button to navigate to the gallery
- Register Route path='*' as the last route in App.tsx so unknown paths render the 404 page instead of a blank screen
- Add pageNotFound and goToGallery translation keys for English and Spanish
- Add CSS styles for the 404 page matching the existing dark theme
- Add 4 unit tests for NotFoundPage

Closes #143