### PR TITLE
docs: fix countdown default from 3s to 7s in SPEC.md

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -77,7 +77,7 @@ Keyboard shortcuts are disabled during the countdown overlay to prevent accident
 
 ### Countdown
 
-- Configurable duration (default: 3 seconds)
+- Configurable duration (default: 7 seconds)
 - Visual countdown displayed prominently
 - Audio feedback (beeps) — future enhancement
 - Countdown cancellation — future enhancement


### PR DESCRIPTION
SPEC.md line 80 incorrectly stated the countdown default as 3 seconds. The actual default is 7000ms (7 seconds) as configured in appsettings.json, Program.cs, CLAUDE.md, and SPEC.md's own configuration table.

Closes #131