### PR TITLE
refactor: extract duplicate generateKenBurnsConfig to shared utility

### DIFF
--- a/src/PhotoBooth.Web/src/components/Slideshow.tsx
+++ b/src/PhotoBooth.Web/src/components/Slideshow.tsx
@@ -3,6 +3,7 @@ import { PhotoDisplay } from './PhotoDisplay';
 import type { KenBurnsConfig } from './PhotoDisplay';
 import { useTranslation } from '../i18n/useTranslation';
 import type { SlideshowPhoto } from '../hooks/useSlideshowNavigation';
+import { generateKenBurnsConfig } from '../utils/kenBurns';
 
 interface SlideshowProps {
   photo: SlideshowPhoto | null;
@@ -12,58 +13,6 @@ interface SlideshowProps {
 }
 
 const FADE_DURATION_MS = 500;
-
-function randomInRange(min: number, max: number): number {
-  return min + Math.random() * (max - min);
-}
-
-function generateKenBurnsConfig(intervalMs: number): KenBurnsConfig {
-  // Random zoom direction: in or out
-  const zoomIn = Math.random() > 0.5;
-
-  // Stronger scale range: 1.08-1.12 to 1.18-1.28
-  const scaleSmall = randomInRange(1.08, 1.12);
-  const scaleLarge = randomInRange(1.18, 1.28);
-
-  // Random pan direction with randomized amount (3-6%)
-  const panAmount = randomInRange(3, 6);
-  const panDirections = [
-    { x: panAmount, y: 0 },      // right
-    { x: -panAmount, y: 0 },     // left
-    { x: 0, y: panAmount },      // down
-    { x: 0, y: -panAmount },     // up
-    { x: panAmount * 0.7, y: panAmount * 0.7 },   // diagonal down-right
-    { x: -panAmount * 0.7, y: panAmount * 0.7 },  // diagonal down-left
-    { x: panAmount * 0.7, y: -panAmount * 0.7 },  // diagonal up-right
-    { x: -panAmount * 0.7, y: -panAmount * 0.7 }, // diagonal up-left
-  ];
-  const pan = panDirections[Math.floor(Math.random() * panDirections.length)];
-
-  // Duration slightly overshoots the slideshow interval to avoid freezing at the end
-  const duration = intervalMs / 1000;
-
-  if (zoomIn) {
-    return {
-      scaleFrom: scaleSmall,
-      scaleTo: scaleLarge,
-      xFrom: '0%',
-      yFrom: '0%',
-      xTo: `${pan.x}%`,
-      yTo: `${pan.y}%`,
-      duration: `${duration.toFixed(1)}s`,
-    };
-  } else {
-    return {
-      scaleFrom: scaleLarge,
-      scaleTo: scaleSmall,
-      xFrom: '0%',
-      yFrom: '0%',
-      xTo: `${pan.x}%`,
-      yTo: `${pan.y}%`,
-      duration: `${duration.toFixed(1)}s`,
-    };
-  }
-}
 
 interface PhotoState {
   photo: SlideshowPhoto;

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { Slideshow } from '../components/Slideshow';
 import { CaptureOverlay } from '../components/CaptureOverlay';
 import { PhotoDisplay, type KenBurnsConfig } from '../components/PhotoDisplay';
+import { generateKenBurnsConfig } from '../utils/kenBurns';
 import { useEventStream } from '../api/events';
 import { triggerCapture } from '../api/client';
 import { useSlideshowNavigation } from '../hooks/useSlideshowNavigation';
@@ -22,52 +23,6 @@ interface BoothPageProps {
   slideshowIntervalMs?: number;
   gamepadConfig?: GamepadConfig | null;
   watchdogTimeoutMs?: number;
-}
-
-function randomInRange(min: number, max: number): number {
-  return min + Math.random() * (max - min);
-}
-
-function generateKenBurnsConfig(intervalMs: number): KenBurnsConfig {
-  const zoomIn = Math.random() > 0.5;
-  const scaleSmall = randomInRange(1.08, 1.12);
-  const scaleLarge = randomInRange(1.18, 1.28);
-  const panAmount = randomInRange(3, 6);
-  const panDirections = [
-    { x: panAmount, y: 0 },
-    { x: -panAmount, y: 0 },
-    { x: 0, y: panAmount },
-    { x: 0, y: -panAmount },
-    { x: panAmount * 0.7, y: panAmount * 0.7 },
-    { x: -panAmount * 0.7, y: panAmount * 0.7 },
-    { x: panAmount * 0.7, y: -panAmount * 0.7 },
-    { x: -panAmount * 0.7, y: -panAmount * 0.7 },
-  ];
-  const pan = panDirections[Math.floor(Math.random() * panDirections.length)];
-  // Duration slightly overshoots the slideshow interval to avoid freezing at the end
-  const duration = intervalMs / 1000;
-
-  if (zoomIn) {
-    return {
-      scaleFrom: scaleSmall,
-      scaleTo: scaleLarge,
-      xFrom: '0%',
-      yFrom: '0%',
-      xTo: `${pan.x}%`,
-      yTo: `${pan.y}%`,
-      duration: `${duration.toFixed(1)}s`,
-    };
-  } else {
-    return {
-      scaleFrom: scaleLarge,
-      scaleTo: scaleSmall,
-      xFrom: '0%',
-      yFrom: '0%',
-      xTo: `${pan.x}%`,
-      yTo: `${pan.y}%`,
-      duration: `${duration.toFixed(1)}s`,
-    };
-  }
 }
 
 interface DisplayPhoto {

--- a/src/PhotoBooth.Web/src/utils/kenBurns.ts
+++ b/src/PhotoBooth.Web/src/utils/kenBurns.ts
@@ -1,0 +1,53 @@
+import type { KenBurnsConfig } from '../components/PhotoDisplay';
+
+function randomInRange(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+export function generateKenBurnsConfig(intervalMs: number): KenBurnsConfig {
+  // Random zoom direction: in or out
+  const zoomIn = Math.random() > 0.5;
+
+  // Stronger scale range: 1.08-1.12 to 1.18-1.28
+  const scaleSmall = randomInRange(1.08, 1.12);
+  const scaleLarge = randomInRange(1.18, 1.28);
+
+  // Random pan direction with randomized amount (3-6%)
+  const panAmount = randomInRange(3, 6);
+  const panDirections = [
+    { x: panAmount, y: 0 },      // right
+    { x: -panAmount, y: 0 },     // left
+    { x: 0, y: panAmount },      // down
+    { x: 0, y: -panAmount },     // up
+    { x: panAmount * 0.7, y: panAmount * 0.7 },   // diagonal down-right
+    { x: -panAmount * 0.7, y: panAmount * 0.7 },  // diagonal down-left
+    { x: panAmount * 0.7, y: -panAmount * 0.7 },  // diagonal up-right
+    { x: -panAmount * 0.7, y: -panAmount * 0.7 }, // diagonal up-left
+  ];
+  const pan = panDirections[Math.floor(Math.random() * panDirections.length)];
+
+  // Duration slightly overshoots the slideshow interval to avoid freezing at the end
+  const duration = intervalMs / 1000;
+
+  if (zoomIn) {
+    return {
+      scaleFrom: scaleSmall,
+      scaleTo: scaleLarge,
+      xFrom: '0%',
+      yFrom: '0%',
+      xTo: `${pan.x}%`,
+      yTo: `${pan.y}%`,
+      duration: `${duration.toFixed(1)}s`,
+    };
+  } else {
+    return {
+      scaleFrom: scaleLarge,
+      scaleTo: scaleSmall,
+      xFrom: '0%',
+      yFrom: '0%',
+      xTo: `${pan.x}%`,
+      yTo: `${pan.y}%`,
+      duration: `${duration.toFixed(1)}s`,
+    };
+  }
+}


### PR DESCRIPTION
Moves the duplicated randomInRange and generateKenBurnsConfig functions from BoothPage.tsx and Slideshow.tsx into a new shared utility src/utils/kenBurns.ts. Both files now import from the utility, eliminating the maintenance risk of keeping two identical implementations in sync. Closes #128