### PR TITLE
docs: document missing configuration settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,12 @@ Example Android configuration:
 | `Booth:RestrictToLocalhost` | Redirect non-localhost users from `/` to `/download` | `true` |
 | `Trigger:RestrictToLocalhost` | Restrict `/api/photos/trigger` to localhost only | `true` |
 | `Capture:RestrictToLocalhost` | Restrict `/api/photos/capture` to localhost only | `true` |
+| `Input:EnableKeyboard` | Enable spacebar to trigger capture | `false` |
+| `NetworkSecurity:BlockOutboundRequests` | Block outbound HTTP requests | `true` |
+| `PhotoStorage:Path` | Where photos are saved | OS-specific app data |
+| `Watchdog:ServerInactivityMinutes` | Restart server after inactivity (0 to disable) | `30` |
+| `Watchdog:ClientTimeoutMs` | Client-side watchdog timeout in ms | `300000` |
+| `Watchdog:SseHeartbeatIntervalSeconds` | SSE heartbeat interval in seconds | `30` |
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ Configuration is done via `appsettings.json` in the Server project. You can dele
       "CaptureLockTimeoutSeconds": 5
     }
   },
+  "Booth": {
+    "RestrictToLocalhost": true
+  },
   "Capture": {
     "CountdownDurationMs": 7000,
     "BufferTimeoutHighLatencyMs": 45000,
-    "BufferTimeoutLowLatencyMs": 12000
+    "BufferTimeoutLowLatencyMs": 12000,
+    "RestrictToLocalhost": true
   },
   "Input": {
     "EnableKeyboard": false
@@ -70,8 +74,16 @@ Configuration is done via `appsettings.json` in the Server project. You can dele
   "PhotoStorage": {
     "Path": ""
   },
+  "Thumbnails": {
+    "JpegQuality": 80
+  },
   "Trigger": {
     "RestrictToLocalhost": true
+  },
+  "Watchdog": {
+    "ServerInactivityMinutes": 30,
+    "ClientTimeoutMs": 300000,
+    "SseHeartbeatIntervalSeconds": 30
   },
   "NetworkSecurity": {
     "BlockOutboundRequests": true
@@ -130,11 +142,18 @@ Requires [ADB](https://developer.android.com/tools/adb) installed and an Android
 
 ### Other Options
 
+- `Booth.RestrictToLocalhost`: Redirect non-localhost users from `/` to `/download` (default: true)
 - `Capture.CountdownDurationMs`: Countdown duration in ms before photo is taken (default: 7000)
 - `Capture.BufferTimeoutHighLatencyMs`: Hard timeout buffer in ms for high-latency cameras (default: 45000)
 - `Capture.BufferTimeoutLowLatencyMs`: Hard timeout buffer in ms for low-latency cameras (default: 12000)
+- `Capture.RestrictToLocalhost`: Restrict capture API to localhost (default: true)
 - `Input.EnableKeyboard`: Enable spacebar key to trigger capture (default: false)
+- `PhotoStorage.Path`: Where photos are saved (defaults to OS-specific app data)
+- `Thumbnails.JpegQuality`: JPEG quality for server-side thumbnails, 0-100 (default: 80)
 - `Trigger.RestrictToLocalhost`: Only allow trigger API from localhost (default: true)
+- `Watchdog.ServerInactivityMinutes`: Restart server after inactivity in minutes, 0 to disable (default: 30)
+- `Watchdog.ClientTimeoutMs`: Client-side watchdog timeout in ms (default: 300000)
+- `Watchdog.SseHeartbeatIntervalSeconds`: SSE heartbeat interval in seconds (default: 30)
 - `NetworkSecurity.BlockOutboundRequests`: Block outbound network requests (default: true)
 - `QrCode.BaseUrl`: Base URL for QR codes (defaults to request origin)
 - `Event.Name`: Event name used as storage subfolder (defaults to current date)

--- a/SPEC.md
+++ b/SPEC.md
@@ -152,6 +152,17 @@ Key configurable parameters:
 | `QrCode:BaseUrl` | Base URL for QR codes | Request origin |
 | `RateLimiting:PermitLimit` | Max requests per rate limit window | `5` |
 | `RateLimiting:WindowSeconds` | Rate limit window in seconds | `10` |
+| `Capture:BufferTimeoutHighLatencyMs` | Hard timeout buffer for high-latency cameras | `45000` |
+| `Capture:BufferTimeoutLowLatencyMs` | Hard timeout buffer for low-latency cameras | `12000` |
+| `Capture:RestrictToLocalhost` | Restrict capture API to localhost | `true` |
+| `Booth:RestrictToLocalhost` | Redirect non-localhost from `/` to `/download` | `true` |
+| `Trigger:RestrictToLocalhost` | Restrict trigger API to localhost | `true` |
+| `Input:EnableKeyboard` | Enable spacebar to trigger capture | `false` |
+| `NetworkSecurity:BlockOutboundRequests` | Block outbound HTTP requests | `true` |
+| `Thumbnails:JpegQuality` | JPEG quality for server-side thumbnails | `80` |
+| `Watchdog:ServerInactivityMinutes` | Restart server after inactivity (0 to disable) | `30` |
+| `Watchdog:ClientTimeoutMs` | Client-side watchdog timeout in ms | `300000` |
+| `Watchdog:SseHeartbeatIntervalSeconds` | SSE heartbeat interval in seconds | `30` |
 
 ## Internationalization (i18n)
 


### PR DESCRIPTION
Adds missing configuration settings to SPEC.md, README.md, and CLAUDE.md.

Settings added:
- Capture:BufferTimeoutHighLatencyMs / BufferTimeoutLowLatencyMs
- Capture:RestrictToLocalhost / Booth:RestrictToLocalhost / Trigger:RestrictToLocalhost
- Input:EnableKeyboard
- NetworkSecurity:BlockOutboundRequests
- PhotoStorage:Path
- Thumbnails:JpegQuality
- Watchdog:ServerInactivityMinutes / ClientTimeoutMs / SseHeartbeatIntervalSeconds

Closes #132