### PR TITLE
refactor: remove dead code PhotoNotFoundException

### DIFF
--- a/src/PhotoBooth.Domain/Exceptions/PhotoBoothException.cs
+++ b/src/PhotoBooth.Domain/Exceptions/PhotoBoothException.cs
@@ -25,19 +25,3 @@ public class CameraNotAvailableException : PhotoBoothException
     {
     }
 }
-
-public class PhotoNotFoundException : PhotoBoothException
-{
-    public PhotoNotFoundException(string code) : base($"Photo with code '{code}' not found")
-    {
-        Code = code;
-    }
-
-    public PhotoNotFoundException(Guid id) : base($"Photo with id '{id}' not found")
-    {
-        PhotoId = id;
-    }
-
-    public string? Code { get; }
-    public Guid? PhotoId { get; }
-}


### PR DESCRIPTION
PhotoNotFoundException was defined in the Domain layer but never thrown, caught, or referenced anywhere. Photo lookup consistently returns null from services and converts to HTTP 404 at the endpoint level.

Closes #135