### PR TITLE
refactor: remove unused CaptureResultDto and CameraInfoDto frontend types

### DIFF
--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -16,17 +16,6 @@ export interface SlideshowPhotoDto {
   imageUrl: string;
 }
 
-export interface CaptureResultDto {
-  id: string;
-  code: string;
-  capturedAt: string;
-}
-
-export interface CameraInfoDto {
-  isAvailable: boolean;
-  captureLatencyMs: number;
-}
-
 export interface TriggerResponse {
   message: string;
   countdownDurationMs: number;


### PR DESCRIPTION
Removes two unused TypeScript interfaces from types.ts that were defined but never imported or used anywhere in the frontend codebase.

Closes #136