### PR TITLE
Remove unused translation keys

### DIFF
--- a/src/PhotoBooth.Web/src/i18n/__tests__/useTranslation.test.ts
+++ b/src/PhotoBooth.Web/src/i18n/__tests__/useTranslation.test.ts
@@ -47,8 +47,8 @@ describe('useTranslation', () => {
     const { result } = renderHook(() => useTranslation());
 
     expect(result.current.t('enterPhotoCode')).toBe('Photo code');
-    expect(result.current.t('searching')).toBe('Searching...');
-    expect(result.current.t('tapToTakePhoto')).toBe('Tap anywhere to take a photo');
+    expect(result.current.t('loading')).toBe('Loading...');
+    expect(result.current.t('pageNotFound')).toBe('Page not found');
   });
 
   it('setLanguage changes the language and updates URL', () => {

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -2,9 +2,7 @@ export const translations = {
   en: {
     // Download page
     enterPhotoCode: 'Photo code',
-    searching: 'Searching...',
     findPhoto: 'Find Photo',
-    photoNotFound: 'Photo not found. Please check your code.',
     getPhoto: 'Get Photo',
     downloadPhoto: 'Download Photo',
     sharePhoto: 'Share Photo',
@@ -19,9 +17,6 @@ export const translations = {
     photoNotFoundError: 'Photo not found',
     backToGallery: 'Back to Gallery',
 
-    // Booth page
-    tapToTakePhoto: 'Tap anywhere to take a photo',
-
     // Slideshow
     noPhotosToShow: 'No photos to show yet',
 
@@ -32,9 +27,7 @@ export const translations = {
   es: {
     // Download page
     enterPhotoCode: 'Código de foto',
-    searching: 'Buscando...',
     findPhoto: 'Buscar Foto',
-    photoNotFound: 'Foto no encontrada. Por favor verifica el código.',
     getPhoto: 'Obtener Foto',
     downloadPhoto: 'Descargar Foto',
     sharePhoto: 'Compartir Foto',
@@ -48,9 +41,6 @@ export const translations = {
     loading: 'Cargando...',
     photoNotFoundError: 'Foto no encontrada',
     backToGallery: 'Volver a la Galería',
-
-    // Booth page
-    tapToTakePhoto: 'Toca en cualquier lugar para tomar una foto',
 
     // Slideshow
     noPhotosToShow: 'Aún no hay fotos para mostrar',


### PR DESCRIPTION
Removes three translation keys that are defined in both en and es locales but never used by any component: searching, photoNotFound, and tapToTakePhoto. The similar key photoNotFoundError is still used and has been kept. Updates the useTranslation test to use valid keys instead. Closes #138