### PR TITLE
feat: add WiX v5 MSI installer for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,12 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          # Strip leading 'v' and any leading dots (e.g. v.0.0.1 -> 0.0.1)
-          VERSION="${VERSION#v}"
-          VERSION="${VERSION#.}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          TAG="${{ github.event.release.tag_name }}"
+          TAG="${TAG#v}"
+          TAG="${TAG#.}"
+          MSI_VERSION=$(echo "$TAG" | grep -oP '^\d+\.\d+\.\d+')
+          echo "version=${TAG}" >> $GITHUB_OUTPUT
+          echo "msi_version=${MSI_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Publish for Windows x64
         run: |
@@ -83,10 +84,25 @@ jobs:
           cd publish/win-x64
           zip -r ../../PhotoBooth-${{ steps.version.outputs.version }}-win-x64.zip .
 
+      - name: Install WiX toolset
+        run: dotnet tool install --global wix
+
+      - name: Add WiX UI extension
+        run: wix extension add WixToolset.UI.wixext
+
+      - name: Build MSI installer
+        run: |
+          wix build installer/PhotoBooth.wxs \
+            -ext WixToolset.UI.wixext \
+            -d ProductVersion=${{ steps.version.outputs.msi_version }} \
+            -d PublishDir=publish/win-x64 \
+            -o PhotoBooth-${{ steps.version.outputs.version }}-win-x64.msi
+
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload ${{ github.event.release.tag_name }} \
             PhotoBooth-${{ steps.version.outputs.version }}-win-x64.zip \
+            PhotoBooth-${{ steps.version.outputs.version }}-win-x64.msi \
             --clobber

--- a/installer/License.rtf
+++ b/installer/License.rtf
@@ -1,0 +1,14 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0\froman\fcharset0 Times New Roman;}}
+{\colortbl;\red0\green0\blue0;}
+\f0\fs20
+MIT License\par
+\par
+Copyright (c) 2026 magnusakselvoll\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
+}

--- a/installer/PhotoBooth.wxs
+++ b/installer/PhotoBooth.wxs
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+
+  <Package Name="PhotoBooth"
+           Manufacturer="magnusakselvoll"
+           Version="$(ProductVersion)"
+           UpgradeCode="3B7A2C1D-4E5F-4A6B-8C9D-0E1F2A3B4C5D"
+           Scope="perUser"
+           Compressed="yes">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of PhotoBooth is already installed."
+                  AllowSameVersionUpgrades="yes" />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <Property Id="REINSTALLMODE" Value="amus" />
+
+    <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT"
+              Value="PhotoBooth has been installed. To get started:&#xA;&#xA;Run PhotoBooth.Server.exe from [INSTALLFOLDER]&#xA;&#xA;Settings file (auto-created on first run): [INSTALLFOLDER]appsettings.json&#xA;Log files: [INSTALLFOLDER]logs\&#xA;Photo storage: %LOCALAPPDATA%\PhotoBooth\Photos" />
+
+    <WixVariable Id="WixUILicenseRtf" Value="$(sys.CURRENTDIR)License.rtf" />
+
+    <ui:WixUI Id="WixUI_InstallDir" />
+
+    <Feature Id="ProductFeature" Title="PhotoBooth" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="StartMenuShortcuts" />
+    </Feature>
+
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="INSTALLFOLDER" Name="PhotoBooth" />
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="PhotoBooth" />
+    </StandardDirectory>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Files Include="$(PublishDir)\**" />
+    </ComponentGroup>
+
+    <ComponentGroup Id="StartMenuShortcuts" Directory="ApplicationProgramsFolder">
+      <Component Id="ApplicationShortcut" Guid="A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5E">
+        <Shortcut Id="AppShortcut"
+                  Name="PhotoBooth"
+                  Description="Photo Booth Application"
+                  Target="[INSTALLFOLDER]PhotoBooth.Server.exe"
+                  WorkingDirectory="INSTALLFOLDER" />
+        <RemoveFolder Id="CleanUpShortCut" Directory="ApplicationProgramsFolder" On="uninstall" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\magnusakselvoll\PhotoBooth"
+                       Name="installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+</Wix>


### PR DESCRIPTION
Adds a proper MSI installer for Windows built with WiX v5 via the dotnet tool.

## Changes

- **installer/PhotoBooth.wxs**: WiX v5 source defining a per-user MSI install to %LOCALAPPDATA%\PhotoBooth, with MajorUpgrade (same-version overwrite), Start Menu shortcut, WixUI_InstallDir dialog chain (welcome, license, directory selection, progress, completion), and exit dialog info showing settings/log/photo paths.
- **installer/License.rtf**: MIT license in RTF format for the installer license screen.
- **.github/workflows/release.yml**: Extracts MSI-safe X.Y.Z version, installs WiX v5, builds the MSI, and uploads both the zip and MSI as release assets.

## Behaviour

- No UAC elevation prompt (per-user install)
- Installs to %LOCALAPPDATA%\PhotoBooth
- Overwrites existing installation of the same or older version cleanly
- Uninstalls cleanly via Windows Settings > Apps
- Start Menu shortcut created during install, removed on uninstall
- appsettings.json is NOT included in the MSI (auto-created by the app on first run, so user settings survive reinstalls)

Closes #178