### PR TITLE
fix: add version to WixToolset.UI.wixext PackageReference in wixproj

### DIFF
--- a/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
+++ b/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
@@ -7,6 +7,6 @@
     <SuppressIces>ICE40;ICE61;ICE91</SuppressIces>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The installer project has a local Directory.Build.props stop file that prevents inheriting ManagePackageVersionsCentrally from the root Directory.Build.props. Without central package management enabled, PackageReference items need explicit versions. WixToolset.UI.wixext had none, causing the release workflow to fail with NU1015 during dotnet restore.

Fix: add Version="5.0.2" directly to the PackageReference in PhotoBooth.Installer.wixproj.