### PR TITLE
fix: suppress ICE64 in WiX installer build

### DIFF
--- a/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
+++ b/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
@@ -4,7 +4,7 @@
     <InstallerPlatform>x64</InstallerPlatform>
     <PublishDir Condition="'$(PublishDir)' == ''">..\..\publish\win-x64\</PublishDir>
     <DefineConstants>ProductVersion=$(InstallerVersion);PublishDir=$(PublishDir)</DefineConstants>
-    <SuppressIces>ICE38;ICE40;ICE61;ICE91</SuppressIces>
+    <SuppressIces>ICE38;ICE40;ICE61;ICE64;ICE91</SuppressIces>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />


### PR DESCRIPTION
ICE64 fires because the auto-harvested `<Files Include>` element creates components for subdirectories (e.g. `wwwroot/` and its children from the frontend build) without `RemoveFolder` entries. This is expected when using WiX v5 auto-harvesting with a per-user install into `LocalAppDataFolder`.

Suppressing ICE64 is the pragmatic fix -- the existing `InstallFolderCleanup` component already has a `RemoveFolder` for the top-level `INSTALLFOLDER`. Consistent with the other ICE suppressions already in place for per-user installs (ICE38, ICE40, ICE61, ICE91).

Fixes the failing release workflow for v0.0.9-alpha.