### PR TITLE
docs: document WiX/MSI installer in SPEC, CLAUDE, and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,13 +226,31 @@ The `/api/photos/capture` and `/api/photos/trigger` endpoints are rate-limited u
 GitHub Actions workflows in `.github/workflows/`:
 
 - **ci.yml**: Runs on PRs and pushes to main. Builds .NET and frontend, runs tests, and lints.
-- **release.yml**: Triggered when a release is published via the GitHub UI. Builds and uploads the Windows x64 executable to the release.
+- **release.yml**: Triggered when a release is published via the GitHub UI. Builds and uploads the Windows x64 standalone zip and MSI installer to the release.
 
 ### Creating a Release
 
 1. Create a release in the GitHub UI (with tag like `v1.0.0`)
 2. The release workflow automatically triggers on publish
-3. The Windows executable is built and uploaded to the release as an asset
+3. Two artifacts are built and uploaded: a standalone zip and an MSI installer (both for Windows x64)
+
+## Installer
+
+The WiX-based MSI installer is in `installer/PhotoBooth.Installer/`.
+
+- **Technology**: WiX Toolset v5.0.2
+- **Install scope**: Per-user (`Scope="perUser"`) — no administrator privileges or UAC elevation required
+- **Install path**: `%LOCALAPPDATA%\PhotoBooth`
+- **Start Menu**: Creates a shortcut under the user's Start Menu
+- **Upgrades**: Major upgrade; installing a newer version replaces the existing one (same-version reinstall also supported)
+- **Suppressed ICEs**: ICE38, ICE40, ICE61, ICE64, ICE91 — required for the per-user install pattern
+
+Build the MSI manually (after publishing the server):
+```bash
+dotnet build installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj --configuration Release -p:InstallerVersion=1.2.3 "-p:PublishDir=publish\win-x64\"
+```
+
+The version is extracted from the git tag in the release workflow (strips `v` prefix and any semver prerelease/build metadata for the MSI version field).
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ A photo booth application for events. Runs unattended with slideshow display, ph
 - **Multiple camera support**: Webcam (via OpenCV), Android phone (via ADB over USB)
 - **Internationalization**: English and Spanish language support with automatic detection and URL override (`?lang=es`)
 
+## Installation (Windows)
+
+Download from [GitHub Releases](https://github.com/magnusakselvoll/photo-booth-take-two/releases):
+
+- **MSI installer** (recommended): No admin rights required — installs per-user to `%LOCALAPPDATA%\PhotoBooth` and adds a Start Menu shortcut. Run the MSI and follow the wizard.
+- **Standalone zip**: Extract and run `PhotoBooth.Server.exe` directly.
+
+After first run, `appsettings.json` is created in the install folder. Logs go to `logs\`, photos to `%LOCALAPPDATA%\PhotoBooth\Photos` (configurable via `PhotoStorage:Path`).
+
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download)
@@ -174,6 +183,8 @@ tests/
   PhotoBooth.Application.Tests/
   PhotoBooth.Infrastructure.Tests/
   PhotoBooth.Server.Tests/
+installer/
+  PhotoBooth.Installer/     # WiX MSI installer (per-user, no elevation)
 ```
 
 ## Acknowledgments

--- a/SPEC.md
+++ b/SPEC.md
@@ -184,6 +184,18 @@ The application runs unattended, so reliability is critical:
 3. **Logging**: Comprehensive logging for post-event debugging
 4. **Watchdog**: Consider self-restart capability if application becomes unresponsive
 
+## Distribution / Installation
+
+Two release formats are published to GitHub Releases for each version:
+
+- **MSI installer** (`PhotoBooth-<version>-win-x64.msi`): Recommended for end users. Installs per-user with no administrator privileges or UAC elevation required. Installs to `%LOCALAPPDATA%\PhotoBooth` and creates a Start Menu shortcut. Supports in-place upgrades — installing a newer version replaces the existing one automatically.
+- **Standalone zip** (`PhotoBooth-<version>-win-x64.zip`): Self-contained executable, extract and run `PhotoBooth.Server.exe` directly.
+
+After installation via MSI:
+- `appsettings.json` is auto-created in the install folder on first run
+- Logs are written to `<install folder>\logs\`
+- Photos are stored in `%LOCALAPPDATA%\PhotoBooth\Photos` (unless overridden via `PhotoStorage:Path`)
+
 ## Non-Goals (Explicitly Out of Scope)
 
 - Cloud storage or sync


### PR DESCRIPTION
Adds documentation for the WiX/MSI installer across all three main docs:

- **SPEC.md**: New "Distribution / Installation" section describing both release formats (MSI and zip), per-user install behavior, and post-install file locations
- **CLAUDE.md**: New "Installer" section with project location, WiX version, per-user scope, install path, build command, suppressed ICEs, and version extraction; updated CI/CD section to mention both artifacts
- **README.md**: New "Installation (Windows)" section for end users; updated Project Structure to include the installer directory