### PR TITLE
fix: prevent scrollbars in slideshow/booth mode

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -25,6 +25,7 @@ body {
   justify-content: center;
   cursor: pointer;
   position: relative;
+  overflow: hidden;
 }
 
 /* Slideshow */
@@ -34,6 +35,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Add overflow:hidden to .booth-page (the actual containing block for absolutely-positioned .photo-display elements) and position:relative to .slideshow so its existing overflow:hidden correctly clips Ken Burns scaled/translated photos.

The Ken Burns animation scales images up to 1.28x. Because .photo-display uses position:absolute, its containing block was .booth-page (not .slideshow), so .slideshow's overflow:hidden had no effect on clipping the scaled content. Neither .booth-page nor any ancestor had overflow:hidden, so scaled photos could trigger scrollbars — especially visible in Edge kiosk mode on Windows.

Closes #188