### PR TITLE
feat: add appsettings.User.json support for upgrade-safe configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.env
+appsettings.User.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,14 @@ Example Android configuration:
 | `Watchdog:ClientTimeoutMs` | Client-side watchdog timeout in ms | `300000` |
 | `Watchdog:SseHeartbeatIntervalSeconds` | SSE heartbeat interval in seconds | `30` |
 
+## User Configuration
+
+`appsettings.json` is overwritten by the MSI installer on every upgrade. To persist customizations across upgrades, users create `appsettings.User.json` in the same directory. It is loaded after `appsettings.json` and overrides any values it contains — only include the settings you want to change.
+
+Loading is handled by `UserSettingsLoader.AddUserSettings` (called in `Program.cs` after `CreateBuilder`). The file is optional; its absence is not an error. A startup log message is emitted when the file is present.
+
+`appsettings.User.json` is excluded from the installer (not part of publish output) and from source control (`.gitignore`).
+
 ## Security
 
 ### HTTP Security Headers

--- a/README.md
+++ b/README.md
@@ -50,7 +50,22 @@ dotnet run --project src/PhotoBooth.Server
 
 ## Configuration
 
-Configuration is done via `appsettings.json` in the Server project. You can delete `appsettings.json` to revert all settings to their defaults.
+Settings are stored in `appsettings.json` in the install folder (`%LOCALAPPDATA%\PhotoBooth` for MSI installs). This file is **overwritten on every upgrade**, so do not edit it directly.
+
+To customize settings that survive upgrades, create `appsettings.User.json` in the same folder. Include only the settings you want to change — they are merged on top of the defaults. Example:
+
+```json
+{
+  "Camera": {
+    "Provider": "Android"
+  },
+  "Event": {
+    "Name": "Wedding2026"
+  }
+}
+```
+
+You can delete `appsettings.json` to restore defaults on next startup, or delete `appsettings.User.json` to remove all customizations.
 
 ```json
 {

--- a/installer/PhotoBooth.Installer/Package.wxs
+++ b/installer/PhotoBooth.Installer/Package.wxs
@@ -20,7 +20,7 @@
     <SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT"
                  Before="ExecuteAction"
                  Sequence="ui"
-                 Value="PhotoBooth has been installed. To get started:&#xA;&#xA;Run PhotoBooth.Server.exe from [INSTALLFOLDER]&#xA;&#xA;Settings file (auto-created on first run): [INSTALLFOLDER]appsettings.json&#xA;Log files: [INSTALLFOLDER]logs\&#xA;Photo storage: %LOCALAPPDATA%\PhotoBooth\Photos" />
+                 Value="PhotoBooth has been installed. To get started:&#xA;&#xA;Run PhotoBooth.Server.exe from [INSTALLFOLDER]&#xA;&#xA;Settings (overwritten on upgrade): [INSTALLFOLDER]appsettings.json&#xA;Custom settings (preserved on upgrade): [INSTALLFOLDER]appsettings.User.json&#xA;Log files: [INSTALLFOLDER]logs\&#xA;Photo storage: %LOCALAPPDATA%\PhotoBooth\Photos" />
 
     <WixVariable Id="WixUILicenseRtf" Value="$(sys.CURRENTDIR)License.rtf" />
 

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -25,6 +25,10 @@ Log.Logger = new LoggerConfiguration()
 DefaultSettingsRestorer.EnsureSettingsExist(AppContext.BaseDirectory);
 
 var builder = WebApplication.CreateBuilder(args);
+
+if (UserSettingsLoader.AddUserSettings(builder.Configuration, AppContext.BaseDirectory))
+    Log.Information("Loaded user configuration from {Path}", Path.Combine(AppContext.BaseDirectory, "appsettings.User.json"));
+
 builder.Host.UseSerilog();
 
 // Add services to the container.

--- a/src/PhotoBooth.Server/UserSettingsLoader.cs
+++ b/src/PhotoBooth.Server/UserSettingsLoader.cs
@@ -1,0 +1,11 @@
+namespace PhotoBooth.Server;
+
+public static class UserSettingsLoader
+{
+    public static bool AddUserSettings(ConfigurationManager configuration, string directory)
+    {
+        var userSettingsPath = Path.Combine(directory, "appsettings.User.json");
+        configuration.AddJsonFile(userSettingsPath, optional: true, reloadOnChange: true);
+        return File.Exists(userSettingsPath);
+    }
+}

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -1,3 +1,6 @@
+// To customize settings that persist across upgrades, create appsettings.User.json
+// in the same folder and put only the settings you want to override there.
+// appsettings.User.json is never overwritten by the installer.
 {
   // Logging configuration
   "Logging": {

--- a/tests/PhotoBooth.Server.Tests/UserSettingsLoaderTests.cs
+++ b/tests/PhotoBooth.Server.Tests/UserSettingsLoaderTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using PhotoBooth.Server;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public class UserSettingsLoaderTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [TestMethod]
+    public void AddUserSettings_UserFileOverridesBaseFile_WhenBothPresent()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"),
+            """{"Camera": {"Provider": "OpenCv"}}""");
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.User.json"),
+            """{"Camera": {"Provider": "Android"}}""");
+
+        var configuration = new ConfigurationManager();
+        configuration.AddJsonFile(Path.Combine(_tempDir, "appsettings.json"), optional: false);
+
+        var found = UserSettingsLoader.AddUserSettings(configuration, _tempDir);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual("Android", configuration["Camera:Provider"]);
+    }
+
+    [TestMethod]
+    public void AddUserSettings_ReturnsFalse_WhenUserFileAbsent()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"),
+            """{"Camera": {"Provider": "OpenCv"}}""");
+
+        var configuration = new ConfigurationManager();
+        configuration.AddJsonFile(Path.Combine(_tempDir, "appsettings.json"), optional: false);
+
+        var found = UserSettingsLoader.AddUserSettings(configuration, _tempDir);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual("OpenCv", configuration["Camera:Provider"]);
+    }
+
+    [TestMethod]
+    public void AddUserSettings_MergesPartialOverride_LeavingUnchangedKeysIntact()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"),
+            """{"Camera": {"Provider": "OpenCv"}, "Event": {"Name": "Default"}}""");
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.User.json"),
+            """{"Event": {"Name": "Wedding2026"}}""");
+
+        var configuration = new ConfigurationManager();
+        configuration.AddJsonFile(Path.Combine(_tempDir, "appsettings.json"), optional: false);
+        UserSettingsLoader.AddUserSettings(configuration, _tempDir);
+
+        Assert.AreEqual("OpenCv", configuration["Camera:Provider"]);
+        Assert.AreEqual("Wedding2026", configuration["Event:Name"]);
+    }
+}


### PR DESCRIPTION
Settings in appsettings.json are overwritten on MSI upgrade. Users can now create appsettings.User.json alongside it with only their customized values. That file is never included in the installer or source control.

- UserSettingsLoader loads the optional file after appsettings.json
- appsettings.json has a comment at the top pointing users to this pattern
- README documents the two-file approach clearly
- 3 unit tests verify override, missing-file, and partial-merge behavior

Closes #190