### PR TITLE
fix: replace Task.Delay race condition in EventBroadcaster tests

### DIFF
--- a/src/PhotoBooth.Infrastructure/Events/EventBroadcaster.cs
+++ b/src/PhotoBooth.Infrastructure/Events/EventBroadcaster.cs
@@ -15,6 +15,8 @@ public class EventBroadcaster : IEventBroadcaster
         _logger = logger;
     }
 
+    public int SubscriberCount { get { lock (_lock) { return _subscribers.Count; } } }
+
     public Task BroadcastAsync(PhotoBoothEvent evt, CancellationToken cancellationToken = default)
     {
         List<Channel<PhotoBoothEvent>> subscribers;

--- a/tests/PhotoBooth.Infrastructure.Tests/EventBroadcasterTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/EventBroadcasterTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using PhotoBooth.Application.Events;
 using PhotoBooth.Infrastructure.Events;
@@ -18,6 +19,14 @@ public class EventBroadcasterTests
             builder.SetMinimumLevel(LogLevel.Debug);
         });
         _logger = loggerFactory.CreateLogger<EventBroadcaster>();
+    }
+
+    private static async Task WaitForSubscribers(EventBroadcaster broadcaster, int expected, int timeoutMs = 2000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (broadcaster.SubscriberCount < expected && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(10);
+        Assert.AreEqual(expected, broadcaster.SubscriberCount, "Subscribers did not connect in time");
     }
 
     [TestMethod]
@@ -48,8 +57,7 @@ public class EventBroadcasterTests
             }
         });
 
-        // Give the subscriber time to connect
-        await Task.Delay(50);
+        await WaitForSubscribers(broadcaster, 1);
 
         // Broadcast
         await broadcaster.BroadcastAsync(evt);
@@ -92,7 +100,7 @@ public class EventBroadcasterTests
             }
         });
 
-        await Task.Delay(50);
+        await WaitForSubscribers(broadcaster, 2);
 
         await broadcaster.BroadcastAsync(evt);
 
@@ -131,8 +139,7 @@ public class EventBroadcasterTests
             subscriptionEnded.SetResult();
         });
 
-        // Give the subscriber time to connect
-        await Task.Delay(50);
+        await WaitForSubscribers(broadcaster, 1);
 
         // Cancel and verify cleanup
         cts.Cancel();


### PR DESCRIPTION
## Summary

- Add  property to  (used by tests only)
- Replace  timing-based waits with a  helper that polls until the expected number of channels are registered
- Fixes flaky  that broke the v0.1.4 release build on the slow Windows CI runner

## Test plan
- [ ] All 4  pass locally
- [ ] Full CI suite passes on this PR

Closes #195