### PR TITLE
Fix 404 not correctly working for unmatched routes

### DIFF
--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -247,9 +247,44 @@ app.MapConfigEndpoints(builder.Configuration, urlPrefix);
 // Root / is served by UseDefaultFiles + UseStaticFiles. All other paths return 404.
 app.MapFallback($"{urlPrefix}/{{**path}}", async context =>
 {
+    var fileInfo = app.Environment.WebRootFileProvider.GetFileInfo("index.html");
+    if (!fileInfo.Exists)
+    {
+        context.Response.StatusCode = StatusCodes.Status404NotFound;
+        context.Response.ContentType = "text/plain";
+        await context.Response.WriteAsync("index.html not found. Has the frontend been built?");
+        return;
+    }
     context.Response.ContentType = "text/html";
-    await context.Response.SendFileAsync(
-        app.Environment.WebRootFileProvider.GetFileInfo("index.html"));
+    await context.Response.SendFileAsync(fileInfo);
+});
+
+// Global catch-all fallback — return a proper 404 page for any unmatched route.
+// Without this, ASP.NET Core returns HTTP 200 with an empty body and no Content-Type,
+// which causes browsers to offer an empty file download (worsened by X-Content-Type-Options: nosniff).
+app.MapFallback(context =>
+{
+    context.Response.StatusCode = StatusCodes.Status404NotFound;
+    context.Response.ContentType = "text/html";
+    return context.Response.WriteAsync("""
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>404 - Not Found</title>
+            <style>
+                body { font-family: system-ui, -apple-system, sans-serif; background: #1a1a1a; color: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100dvh; margin: 0; }
+                .code { font-size: 8rem; font-weight: 700; color: #666; line-height: 1; }
+                .message { font-size: 1.25rem; }
+            </style>
+        </head>
+        <body>
+            <span class="code">404</span>
+            <p class="message">Page not found</p>
+        </body>
+        </html>
+        """);
 });
 
 app.Run();

--- a/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
+++ b/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using PhotoBooth.Domain.Interfaces;
+using PhotoBooth.Infrastructure.Camera;
+using PhotoBooth.Infrastructure.Storage;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+[TestCategory("Integration")]
+public sealed class FallbackRouteTests
+{
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    var cameraDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICameraProvider));
+                    if (cameraDescriptor != null)
+                    {
+                        services.Remove(cameraDescriptor);
+                    }
+
+                    var repoDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IPhotoRepository));
+                    if (repoDescriptor != null)
+                    {
+                        services.Remove(repoDescriptor);
+                    }
+
+                    services.AddSingleton<ICameraProvider>(new MockCameraProvider(isAvailable: true));
+                    services.AddSingleton<IPhotoRepository, InMemoryPhotoRepository>();
+                });
+            });
+
+        _client = _factory.CreateClient();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    [TestMethod]
+    public async Task UnmatchedUrl_Returns404()
+    {
+        var response = await _client.GetAsync("/nonexistent/path");
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task UnmatchedUrl_ReturnsHtmlBody()
+    {
+        var response = await _client.GetAsync("/nonexistent/path");
+
+        Assert.AreEqual("text/html", response.Content.Headers.ContentType?.MediaType);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("404", body);
+        Assert.Contains("Page not found", body);
+    }
+
+    [TestMethod]
+    public async Task UnmatchedUrl_ContainsSecurityHeaders()
+    {
+        var response = await _client.GetAsync("/nonexistent/path");
+
+        Assert.AreEqual("nosniff", response.Headers.GetValues("X-Content-Type-Options").First());
+    }
+
+    [TestMethod]
+    public async Task SpaFallbackWithMissingIndexHtml_Returns404()
+    {
+        // When index.html is absent (frontend not built), the SPA fallback should
+        // return 404 rather than an empty 200 or throw a 500.
+        // In the test environment the wwwroot directory is not populated, so this
+        // verifies the existence guard added to the SPA MapFallback handler.
+        var config = await _client.GetStringAsync("/api/config");
+        var urlPrefix = System.Text.Json.JsonDocument.Parse(config)
+            .RootElement.GetProperty("urlPrefix").GetString()!;
+
+        var response = await _client.GetAsync($"/{urlPrefix}/photo/1");
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary

- Unmatched URLs (outside the URL prefix) returned HTTP 200 with an empty body and no Content-Type, causing browsers to offer an empty file download instead of a 404 page
- Root cause: the SPA fallback only matches paths under the correct URL prefix; paths outside it had no handler
- Add a parameterless MapFallback that returns HTTP 404 with a minimal HTML page for all other unmatched routes
- Guard the existing SPA fallback against a missing index.html (returns 404 with a plain-text message instead of failing)
- Add FallbackRouteTests covering both scenarios

Closes #206