### PR TITLE
fix: check Host header in IsLocalhost to block reverse-proxy bypass

### DIFF
--- a/src/PhotoBooth.Server/Endpoints/CameraEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/CameraEndpoints.cs
@@ -5,12 +5,17 @@ namespace PhotoBooth.Server.Endpoints;
 
 public static class CameraEndpoints
 {
-    public static void MapCameraEndpoints(this IEndpointRouteBuilder app)
+    public static void MapCameraEndpoints(this IEndpointRouteBuilder app, IEndpointFilter? cameraFilter = null)
     {
         var group = app.MapGroup("/api/camera");
 
-        group.MapGet("/info", GetCameraInfo)
+        var infoEndpoint = group.MapGet("/info", GetCameraInfo)
             .WithName("GetCameraInfo");
+
+        if (cameraFilter is not null)
+        {
+            infoEndpoint.AddEndpointFilter(cameraFilter);
+        }
     }
 
     private static async Task<IResult> GetCameraInfo(

--- a/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
+++ b/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
@@ -23,11 +23,12 @@ public class LocalhostOnlyFilter : IEndpointFilter
             return await next(context);
         }
 
-        var remoteIp = context.HttpContext.Connection.RemoteIpAddress;
-
-        if (!NetworkUtilities.IsLocalhost(remoteIp))
+        if (!NetworkUtilities.IsLocalhost(context.HttpContext))
         {
-            _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}", _endpointName, remoteIp);
+            _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}, Host: {Host}",
+                _endpointName,
+                context.HttpContext.Connection.RemoteIpAddress,
+                context.HttpContext.Request.Host);
             return Results.Forbid();
         }
 

--- a/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
+++ b/src/PhotoBooth.Server/Filters/LocalhostOnlyFilter.cs
@@ -25,10 +25,7 @@ public class LocalhostOnlyFilter : IEndpointFilter
 
         if (!NetworkUtilities.IsLocalhost(context.HttpContext))
         {
-            _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}, Host: {Host}",
-                _endpointName,
-                context.HttpContext.Connection.RemoteIpAddress,
-                context.HttpContext.Request.Host);
+            _logger.LogWarning("Blocked {EndpointName} request from non-localhost IP: {RemoteIp}", _endpointName, context.HttpContext.Connection.RemoteIpAddress);
             return Results.Forbid();
         }
 

--- a/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothRedirectMiddleware.cs
@@ -17,7 +17,7 @@ public sealed class BoothRedirectMiddleware
 
     public Task InvokeAsync(HttpContext context)
     {
-        if (_enabled && IsRootPath(context.Request.Path) && !NetworkUtilities.IsLocalhost(context.Connection.RemoteIpAddress))
+        if (_enabled && IsRootPath(context.Request.Path) && !NetworkUtilities.IsLocalhost(context))
         {
             context.Response.Redirect($"/{_urlPrefix}/download", permanent: false);
             return Task.CompletedTask;

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -237,9 +237,16 @@ var captureLocalhostFilter = new LocalhostOnlyFilter(
     "capture",
     app.Services.GetRequiredService<ILogger<LocalhostOnlyFilter>>());
 
+// Create localhost-only filter for camera endpoint
+var restrictCameraToLocalhost = builder.Configuration.GetValue<bool?>("Camera:RestrictToLocalhost") ?? true;
+var cameraLocalhostFilter = new LocalhostOnlyFilter(
+    restrictCameraToLocalhost,
+    "camera",
+    app.Services.GetRequiredService<ILogger<LocalhostOnlyFilter>>());
+
 // Map endpoints
 app.MapPhotoEndpoints(triggerLocalhostFilter, captureLocalhostFilter);
-app.MapCameraEndpoints();
+app.MapCameraEndpoints(cameraLocalhostFilter);
 app.MapEventsEndpoints();
 app.MapConfigEndpoints(builder.Configuration, urlPrefix);
 

--- a/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
+++ b/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
@@ -4,6 +4,14 @@ namespace PhotoBooth.Server.Utilities;
 
 public static class NetworkUtilities
 {
+    private static readonly HashSet<string> LocalhostHostNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "[::1]"
+    };
+
     public static bool IsLocalhost(IPAddress? ipAddress)
     {
         if (ipAddress is null)
@@ -24,5 +32,27 @@ public static class NetworkUtilities
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns true only when both the remote IP is a loopback address AND the Host header
+    /// resolves to a localhost name. This guards against local reverse proxies (e.g. Tailscale
+    /// Serve) that connect to Kestrel from 127.0.0.1 on behalf of remote clients.
+    /// </summary>
+    public static bool IsLocalhost(HttpContext httpContext)
+    {
+        if (!IsLocalhost(httpContext.Connection.RemoteIpAddress))
+        {
+            return false;
+        }
+
+        var host = httpContext.Request.Host.Host;
+
+        if (string.IsNullOrEmpty(host))
+        {
+            return false;
+        }
+
+        return LocalhostHostNames.Contains(host);
     }
 }

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -130,6 +130,11 @@
     "RestrictToLocalhost": true
   },
 
+  // Camera info endpoint security
+  "Camera": {
+    "RestrictToLocalhost": true
+  },
+
   // Network security (blocks outbound HTTP requests)
   "NetworkSecurity": {
     "BlockOutboundRequests": true

--- a/tests/PhotoBooth.Server.Tests/BoothRedirectMiddlewareTests.cs
+++ b/tests/PhotoBooth.Server.Tests/BoothRedirectMiddlewareTests.cs
@@ -158,11 +158,35 @@ public sealed class BoothRedirectMiddlewareTests
         Assert.AreEqual("/abc1234567/download", context.Response.Headers.Location.ToString());
     }
 
-    private static HttpContext CreateContext(IPAddress? remoteIp, string path)
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_RedirectsReverseProxiedRequestFromRoot()
+    {
+        // Arrange — Tailscale Serve / local reverse proxy scenario:
+        // RemoteIpAddress is 127.0.0.1 (proxy connects locally) but Host header reveals
+        // the original external domain, so the request must still be treated as remote.
+        var nextCalled = false;
+        var middleware = new BoothRedirectMiddleware(enabled: true, urlPrefix: "abc1234567", next: _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateContext(IPAddress.Loopback, "/", host: "xxx.tailxxxx.ts.net");
+
+        // Act
+        await middleware.InvokeAsync(context);
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called for reverse-proxied request with external Host");
+        Assert.AreEqual(StatusCodes.Status302Found, context.Response.StatusCode);
+        Assert.AreEqual("/abc1234567/download", context.Response.Headers.Location.ToString());
+    }
+
+    private static HttpContext CreateContext(IPAddress? remoteIp, string path, string host = "localhost")
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Connection.RemoteIpAddress = remoteIp;
         httpContext.Request.Path = path;
+        httpContext.Request.Host = new HostString(host);
         return httpContext;
     }
 }

--- a/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
+++ b/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
@@ -150,10 +150,31 @@ public sealed class LocalhostOnlyFilterTests
         Assert.IsFalse(nextCalled, "Next delegate should not be called when IP is null (fail-secure)");
     }
 
-    private static EndpointFilterInvocationContext CreateContext(IPAddress? remoteIp)
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_BlocksReverseProxiedRequest()
+    {
+        // Arrange — Tailscale Serve / local reverse proxy scenario:
+        // RemoteIpAddress is 127.0.0.1 but Host header is an external domain.
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
+        var context = CreateContext(IPAddress.Loopback, host: "xxx.tailxxxx.ts.net");
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called for reverse-proxied request with external Host");
+    }
+
+    private static EndpointFilterInvocationContext CreateContext(IPAddress? remoteIp, string host = "localhost")
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Connection.RemoteIpAddress = remoteIp;
+        httpContext.Request.Host = new HostString(host);
         return new DefaultEndpointFilterInvocationContext(httpContext);
     }
 }

--- a/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
+++ b/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.AspNetCore.Http;
 using PhotoBooth.Server.Utilities;
 
 namespace PhotoBooth.Server.Tests;
@@ -9,7 +10,7 @@ public sealed class NetworkUtilitiesTests
     [TestMethod]
     public void IsLocalhost_WhenNull_ReturnsFalse()
     {
-        Assert.IsFalse(NetworkUtilities.IsLocalhost(null));
+        Assert.IsFalse(NetworkUtilities.IsLocalhost((IPAddress?)null));
     }
 
     [TestMethod]
@@ -40,5 +41,79 @@ public sealed class NetworkUtilitiesTests
     public void IsLocalhost_WhenExternalIPv6_ReturnsFalse()
     {
         Assert.IsFalse(NetworkUtilities.IsLocalhost(IPAddress.Parse("2001:db8::1")));
+    }
+
+    // Tests for IsLocalhost(HttpContext) overload
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenLoopbackIPAndLocalhostHost_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "localhost")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenLoopbackIPAnd127Host_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "127.0.0.1")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIPv6LoopbackAndIPv6LoopbackHost_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.IPv6Loopback, "::1")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenLoopbackIPAndLocalhostHostWithPort_ReturnsTrue()
+    {
+        // Request.Host.Host strips the port, so "localhost:5192" → "localhost"
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "localhost", 5192)));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIPv4MappedLoopbackAndLocalhostHost_ReturnsTrue()
+    {
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback.MapToIPv6(), "localhost")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenLoopbackIPAndExternalHost_ReturnsFalse()
+    {
+        // This is the reverse-proxy bug scenario: Tailscale Serve connects from 127.0.0.1
+        // but the Host header is the external Tailscale domain
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "xxx.tailxxxx.ts.net")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenExternalIPAndLocalhostHost_ReturnsFalse()
+    {
+        // Spoofed Host header — IP check fails first
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Parse("192.168.1.100"), "localhost")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenExternalIPAndExternalHost_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Parse("192.168.1.100"), "192.168.1.50")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenNullIPAndLocalhostHost_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(null, "localhost")));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenLoopbackIPAndEmptyHost_ReturnsFalse()
+    {
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "")));
+    }
+
+    private static HttpContext CreateContext(IPAddress? remoteIp, string host, int? port = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = remoteIp;
+        httpContext.Request.Host = port.HasValue ? new HostString(host, port.Value) : new HostString(host);
+        return httpContext;
     }
 }


### PR DESCRIPTION
## Summary

- Fixes RestrictToLocalhost not working when Tailscale Serve (or any local reverse proxy) is used: the proxy connects to Kestrel from 127.0.0.1, making RemoteIpAddress appear local for all remote clients
- Fix: NetworkUtilities.IsLocalhost(HttpContext) now requires both a loopback RemoteIpAddress AND a localhost Host header (localhost, 127.0.0.1, ::1) — a request via https://xxx.tailxxxx.ts.net/ has Host: xxx.tailxxxx.ts.net and is correctly treated as remote
- Also restricts /api/camera/info to localhost (only the booth page uses it)
- 10 new tests covering the reverse-proxy scenario; all 94 tests pass

Closes #205