### PR TITLE
fix: serve index.html from root path catch-all when static files fail

### DIFF
--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -223,6 +223,11 @@ app.UseRateLimiter();
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
+// Log web root for diagnostics (missing index.html causes / to 404)
+var webRootPath = app.Environment.WebRootPath;
+var indexExists = app.Environment.WebRootFileProvider.GetFileInfo("index.html").Exists;
+Log.Information("Web root path: {WebRootPath}, index.html exists: {IndexExists}", webRootPath, indexExists);
+
 // Create localhost-only filter for trigger endpoint
 var restrictTriggerToLocalhost = builder.Configuration.GetValue<bool?>("Trigger:RestrictToLocalhost") ?? true;
 var triggerLocalhostFilter = new LocalhostOnlyFilter(
@@ -269,11 +274,30 @@ app.MapFallback($"{urlPrefix}/{{**path}}", async context =>
 // Global catch-all fallback — return a proper 404 page for any unmatched route.
 // Without this, ASP.NET Core returns HTTP 200 with an empty body and no Content-Type,
 // which causes browsers to offer an empty file download (worsened by X-Content-Type-Options: nosniff).
-app.MapFallback(context =>
+app.MapFallback(async context =>
 {
+    // Root path: UseDefaultFiles/UseStaticFiles didn't serve index.html (likely missing from
+    // wwwroot), so handle it the same way as the SPA fallback — serve the file or explain
+    // what's missing.
+    if (context.Request.Path == "/" || !context.Request.Path.HasValue)
+    {
+        var fileInfo = app.Environment.WebRootFileProvider.GetFileInfo("index.html");
+        if (fileInfo.Exists)
+        {
+            context.Response.ContentType = "text/html";
+            await context.Response.SendFileAsync(fileInfo);
+            return;
+        }
+
+        context.Response.StatusCode = StatusCodes.Status404NotFound;
+        context.Response.ContentType = "text/plain";
+        await context.Response.WriteAsync("index.html not found. Has the frontend been built?");
+        return;
+    }
+
     context.Response.StatusCode = StatusCodes.Status404NotFound;
     context.Response.ContentType = "text/html";
-    return context.Response.WriteAsync("""
+    await context.Response.WriteAsync("""
         <!DOCTYPE html>
         <html lang="en">
         <head>

--- a/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
+++ b/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
@@ -20,6 +20,10 @@ public sealed class FallbackRouteTests
         _factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
+                // Disable booth redirect so test requests (which have no RemoteIpAddress)
+                // reach the fallback handlers rather than being redirected to the gallery.
+                builder.UseSetting("Booth:RestrictToLocalhost", "false");
+
                 builder.ConfigureServices(services =>
                 {
                     var cameraDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICameraProvider));
@@ -90,5 +94,18 @@ public sealed class FallbackRouteTests
         var response = await _client.GetAsync($"/{urlPrefix}/photo/1");
 
         Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task RootPathWithMissingIndexHtml_Returns404WithDiagnosticMessage()
+    {
+        // When index.html is absent, requesting / should return 404 with a diagnostic
+        // plain-text message rather than the generic styled 404 HTML page.
+        var response = await _client.GetAsync("/");
+
+        Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.AreEqual("text/plain", response.Content.Headers.ContentType?.MediaType);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("index.html not found", body);
     }
 }


### PR DESCRIPTION
## Summary

- Adds defensive root path handling in the global catch-all: when  reaches it (because / couldn't serve ), it now serves the file directly if it exists, or returns a plain-text diagnostic message instead of a generic 404 HTML page
- Adds startup logging of  and  existence for immediate diagnosis from logs
- Updates : disables booth redirect in the test factory (needed since test requests have no ) and adds a test for the new root path behavior

## Test plan

- [ ] CI passes (integration tests run with unpopulated wwwroot, so  exercises the missing-file branch)
- [ ] On the Windows deployment, the startup log now shows  — if , that confirms the missing file and the page will show the diagnostic message instead of a generic 404

Closes #209