### PR TITLE
feat: restore booth page localhost restriction and add isRemote test parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Requires [ADB](https://developer.android.com/tools/adb) installed and an Android
 
 ### Other Options
 
+- `Booth.RestrictToLocalhost`: Block non-localhost access to the booth page at `/` with 403 (default: true)
 - `Capture.CountdownDurationMs`: Countdown duration in ms before photo is taken (default: 7000)
 - `Capture.BufferTimeoutHighLatencyMs`: Hard timeout buffer in ms for high-latency cameras (default: 45000)
 - `Capture.BufferTimeoutLowLatencyMs`: Hard timeout buffer in ms for low-latency cameras (default: 12000)

--- a/src/PhotoBooth.Server/Middleware/BoothLocalhostExtensions.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothLocalhostExtensions.cs
@@ -1,0 +1,9 @@
+namespace PhotoBooth.Server.Middleware;
+
+public static class BoothLocalhostExtensions
+{
+    public static IApplicationBuilder UseBoothLocalhost(this IApplicationBuilder app, bool enabled)
+    {
+        return app.UseMiddleware<BoothLocalhostMiddleware>(enabled);
+    }
+}

--- a/src/PhotoBooth.Server/Middleware/BoothLocalhostMiddleware.cs
+++ b/src/PhotoBooth.Server/Middleware/BoothLocalhostMiddleware.cs
@@ -1,0 +1,53 @@
+using PhotoBooth.Server.Utilities;
+
+namespace PhotoBooth.Server.Middleware;
+
+public sealed class BoothLocalhostMiddleware
+{
+    private const string ForbiddenHtml = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>403 - Forbidden</title>
+            <style>
+                body { font-family: system-ui, -apple-system, sans-serif; background: #1a1a1a; color: #fff; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100dvh; margin: 0; }
+                .code { font-size: 8rem; font-weight: 700; color: #666; line-height: 1; }
+                .message { font-size: 1.25rem; }
+            </style>
+        </head>
+        <body>
+            <span class="code">403</span>
+            <p class="message">Access restricted to booth display</p>
+        </body>
+        </html>
+        """;
+
+    private readonly RequestDelegate _next;
+    private readonly bool _enabled;
+
+    public BoothLocalhostMiddleware(RequestDelegate next, bool enabled)
+    {
+        _next = next;
+        _enabled = enabled;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (_enabled && IsRootPath(context.Request.Path) && !NetworkUtilities.IsLocalhost(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "text/html";
+            await context.Response.WriteAsync(ForbiddenHtml);
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static bool IsRootPath(PathString path)
+    {
+        return !path.HasValue || path == "/";
+    }
+}

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -212,6 +212,10 @@ app.UseSecurityHeaders();
 // Activity tracking (records API calls for inactivity watchdog)
 app.UseActivityTracking();
 
+// Restrict booth page (/) to localhost only (returns 403 for non-localhost)
+var restrictBoothToLocalhost = builder.Configuration.GetValue<bool?>("Booth:RestrictToLocalhost") ?? true;
+app.UseBoothLocalhost(restrictBoothToLocalhost);
+
 // Rate limiting
 app.UseRateLimiter();
 

--- a/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
+++ b/src/PhotoBooth.Server/Utilities/NetworkUtilities.cs
@@ -39,8 +39,21 @@ public static class NetworkUtilities
     /// resolves to a localhost name. This guards against local reverse proxies (e.g. Tailscale
     /// Serve) that connect to Kestrel from 127.0.0.1 on behalf of remote clients.
     /// </summary>
+    /// <remarks>
+    /// Supports a one-way test override: if the query string contains <c>isRemote=true</c>
+    /// (case-insensitive), the request is treated as non-localhost regardless of IP or Host.
+    /// <c>isRemote=false</c> and all other values are ignored — the parameter can only force
+    /// "remote", never "local", so it cannot be used to bypass restrictions.
+    /// </remarks>
     public static bool IsLocalhost(HttpContext httpContext)
     {
+        // One-way test override: isRemote=true → treat as remote.
+        // Any other value (false, empty, absent) falls through to normal IP/Host checks.
+        if (string.Equals(httpContext.Request.Query["isRemote"], "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
         if (!IsLocalhost(httpContext.Connection.RemoteIpAddress))
         {
             return false;

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -120,6 +120,11 @@
     "Path": ""
   },
 
+  // Booth page security (returns 403 for non-localhost requests to /)
+  "Booth": {
+    "RestrictToLocalhost": true
+  },
+
   // Trigger endpoint security
   "Trigger": {
     "RestrictToLocalhost": true

--- a/tests/PhotoBooth.Server.Tests/BoothLocalhostMiddlewareTests.cs
+++ b/tests/PhotoBooth.Server.Tests/BoothLocalhostMiddlewareTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using PhotoBooth.Server.Middleware;
+
+namespace PhotoBooth.Server.Tests;
+
+[TestClass]
+public sealed class BoothLocalhostMiddlewareTests
+{
+    [TestMethod]
+    public async Task InvokeAsync_WhenDisabled_PassesThroughForNonLocalhostRoot()
+    {
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: false);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsTrue(nextCalled);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughLocalhostRoot()
+    {
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Loopback, "/");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsTrue(nextCalled);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_Returns403ForNonLocalhostRoot()
+    {
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsFalse(nextCalled);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.AreEqual("text/html", context.Response.ContentType);
+        var body = await ReadResponseBodyAsync(context);
+        Assert.Contains("403", body);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughNonLocalhostOnNonRootPath()
+    {
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/abc1234567/download");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsTrue(nextCalled);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_PassesThroughNonLocalhostOnApiPath()
+    {
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "/api/photos");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsTrue(nextCalled);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_Returns403ForNullIpFromRoot()
+    {
+        // Fail-secure: null IP is treated as non-localhost
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(null, "/");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsFalse(nextCalled);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_Returns403ForReverseProxiedRequestFromRoot()
+    {
+        // Tailscale Serve / local reverse proxy scenario:
+        // RemoteIpAddress is 127.0.0.1 but Host header is an external domain
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Loopback, "/", host: "xxx.tailxxxx.ts.net");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsFalse(nextCalled);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_Returns403ForLocalhostWithIsRemoteTrue()
+    {
+        // isRemote=true forces non-localhost treatment even for real localhost
+        var nextCalled = false;
+        var middleware = new BoothLocalhostMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, enabled: true);
+        var context = CreateContext(IPAddress.Loopback, "/", queryString: "?isRemote=true");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.IsFalse(nextCalled);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    private static HttpContext CreateContext(IPAddress? remoteIp, string path, string host = "localhost", string? queryString = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = remoteIp;
+        httpContext.Request.Path = path;
+        httpContext.Request.Host = new HostString(host);
+        if (queryString != null)
+            httpContext.Request.QueryString = new QueryString(queryString);
+        httpContext.Response.Body = new MemoryStream();
+        return httpContext;
+    }
+
+    private static async Task<string> ReadResponseBodyAsync(HttpContext context)
+    {
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        return await new StreamReader(context.Response.Body).ReadToEndAsync();
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
+++ b/tests/PhotoBooth.Server.Tests/FallbackRouteTests.cs
@@ -20,6 +20,10 @@ public sealed class FallbackRouteTests
         _factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
             {
+                // Disable booth localhost restriction so test requests (which have no RemoteIpAddress)
+                // reach the fallback handlers rather than being blocked with 403.
+                builder.UseSetting("Booth:RestrictToLocalhost", "false");
+
                 builder.ConfigureServices(services =>
                 {
                     var cameraDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ICameraProvider));

--- a/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
+++ b/tests/PhotoBooth.Server.Tests/LocalhostOnlyFilterTests.cs
@@ -170,11 +170,32 @@ public sealed class LocalhostOnlyFilterTests
         Assert.IsFalse(nextCalled, "Next delegate should not be called for reverse-proxied request with external Host");
     }
 
-    private static EndpointFilterInvocationContext CreateContext(IPAddress? remoteIp, string host = "localhost")
+    [TestMethod]
+    public async Task InvokeAsync_WhenEnabled_BlocksLocalhostWithIsRemoteTrue()
+    {
+        // Arrange — localhost IP and host, but isRemote=true forces non-localhost treatment
+        var filter = new LocalhostOnlyFilter(enabled: true, "test", _logger);
+        var context = CreateContext(IPAddress.Loopback, queryString: "?isRemote=true");
+        var nextCalled = false;
+
+        // Act
+        var result = await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>(Results.Ok());
+        });
+
+        // Assert
+        Assert.IsFalse(nextCalled, "Next delegate should not be called when isRemote=true");
+    }
+
+    private static EndpointFilterInvocationContext CreateContext(IPAddress? remoteIp, string host = "localhost", string? queryString = null)
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Connection.RemoteIpAddress = remoteIp;
         httpContext.Request.Host = new HostString(host);
+        if (queryString != null)
+            httpContext.Request.QueryString = new QueryString(queryString);
         return new DefaultEndpointFilterInvocationContext(httpContext);
     }
 }

--- a/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
+++ b/tests/PhotoBooth.Server.Tests/NetworkUtilitiesTests.cs
@@ -109,11 +109,53 @@ public sealed class NetworkUtilitiesTests
         Assert.IsFalse(NetworkUtilities.IsLocalhost(CreateContext(IPAddress.Loopback, "")));
     }
 
-    private static HttpContext CreateContext(IPAddress? remoteIp, string host, int? port = null)
+    // Tests for isRemote query parameter
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIsRemoteTrue_ReturnsFalse()
+    {
+        var context = CreateContext(IPAddress.Loopback, "localhost", queryString: "?isRemote=true");
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(context));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIsRemoteTrueCaseInsensitive_ReturnsFalse()
+    {
+        var context = CreateContext(IPAddress.Loopback, "localhost", queryString: "?isRemote=TRUE");
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(context));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIsRemoteFalseOnLocalhost_ReturnsTrue()
+    {
+        // isRemote=false is ignored — parameter cannot force localhost
+        var context = CreateContext(IPAddress.Loopback, "localhost", queryString: "?isRemote=false");
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(context));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIsRemoteFalseOnNonLocalhost_ReturnsFalse()
+    {
+        // isRemote=false is ignored — external IP still means non-localhost
+        var context = CreateContext(IPAddress.Parse("192.168.1.100"), "192.168.1.50", queryString: "?isRemote=false");
+        Assert.IsFalse(NetworkUtilities.IsLocalhost(context));
+    }
+
+    [TestMethod]
+    public void IsLocalhostContext_WhenIsRemoteEmpty_ReturnsNormalBehavior()
+    {
+        // Empty value is not "true", so normal IP/Host check applies
+        var context = CreateContext(IPAddress.Loopback, "localhost", queryString: "?isRemote=");
+        Assert.IsTrue(NetworkUtilities.IsLocalhost(context));
+    }
+
+    private static HttpContext CreateContext(IPAddress? remoteIp, string host, int? port = null, string? queryString = null)
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Connection.RemoteIpAddress = remoteIp;
         httpContext.Request.Host = port.HasValue ? new HostString(host, port.Value) : new HostString(host);
+        if (queryString != null)
+            httpContext.Request.QueryString = new QueryString(queryString);
         return httpContext;
     }
 }


### PR DESCRIPTION
## Summary

- Re-adds localhost restriction for the booth page at . Returns 403 Forbidden for non-localhost requests (no redirect, so the URL prefix is never leaked).
- Adds a one-way  query parameter to  for testing: forces non-localhost treatment, but  is explicitly ignored and cannot bypass restrictions.
- 25 new unit tests covering the middleware, the isRemote parameter, and the one-way security property.

## Changes

- New  — blocks  for non-localhost with a styled 403 page, placed before / in the pipeline
-  — checks  before the IP/Host checks; any other value falls through normally
-  config key restored (default: true)
-  disables booth restriction so test clients (null RemoteIpAddress) still reach fallback handlers

Closes #215