### PR TITLE
feat: add pinch/wheel zoom and pan to photo detail page

### DIFF
--- a/src/PhotoBooth.Web/package.json
+++ b/src/PhotoBooth.Web/package.json
@@ -15,7 +15,8 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-qr-code": "^2.0.18",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "react-zoom-pan-pinch": "^4.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/PhotoBooth.Web/pnpm-lock.yaml
+++ b/src/PhotoBooth.Web/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -521,66 +524,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1260,6 +1276,13 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-zoom-pan-pinch@4.0.3:
+    resolution: {integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -2672,6 +2695,11 @@ snapshots:
       react: 19.2.4
       set-cookie-parser: 2.7.2
     optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react-zoom-pan-pinch@4.0.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}

--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -388,6 +388,20 @@ body {
   overflow: hidden;
 }
 
+.photo-detail-zoom-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photo-detail-zoom-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .photo-detail-image {
   max-width: 100%;
   max-height: 100%;

--- a/src/PhotoBooth.Web/src/hooks/__tests__/useSwipeNavigation.test.ts
+++ b/src/PhotoBooth.Web/src/hooks/__tests__/useSwipeNavigation.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSwipeNavigation } from '../useSwipeNavigation';
+
+function makeTouchLike(clientX: number, clientY: number) {
+  return { clientX, clientY, identifier: 1 };
+}
+
+function dispatchTouch(
+  el: HTMLElement,
+  type: string,
+  touches: Array<{ clientX: number; clientY: number; identifier: number }>,
+  changedTouches?: Array<{ clientX: number; clientY: number; identifier: number }>,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as unknown as TouchEvent;
+  const touchesArr = Object.assign([...touches], { length: touches.length, item: (i: number) => touches[i] });
+  const changedArr = Object.assign([...(changedTouches ?? touches)], {
+    length: (changedTouches ?? touches).length,
+    item: (i: number) => (changedTouches ?? touches)[i],
+  });
+  Object.defineProperty(event, 'touches', { value: touchesArr });
+  Object.defineProperty(event, 'changedTouches', { value: changedArr });
+  el.dispatchEvent(event);
+}
+
+function swipeLeft(el: HTMLElement) {
+  const start = makeTouchLike(200, 100);
+  const end = makeTouchLike(80, 100);
+  dispatchTouch(el, 'touchstart', [start]);
+  dispatchTouch(el, 'touchmove', [end]);
+  dispatchTouch(el, 'touchend', [], [end]);
+  el.dispatchEvent(new Event('transitionend', { bubbles: false }));
+}
+
+function swipeRight(el: HTMLElement) {
+  const start = makeTouchLike(80, 100);
+  const end = makeTouchLike(200, 100);
+  dispatchTouch(el, 'touchstart', [start]);
+  dispatchTouch(el, 'touchmove', [end]);
+  dispatchTouch(el, 'touchend', [], [end]);
+  el.dispatchEvent(new Event('transitionend', { bubbles: false }));
+}
+
+describe('useSwipeNavigation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls onSwipeLeft when swiping left beyond threshold', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const elementRef = { current: el };
+    const onSwipeLeft = vi.fn();
+
+    renderHook(() => useSwipeNavigation({ onSwipeLeft, elementRef }));
+    act(() => swipeLeft(el));
+
+    expect(onSwipeLeft).toHaveBeenCalledOnce();
+    document.body.removeChild(el);
+  });
+
+  it('calls onSwipeRight when swiping right beyond threshold', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const elementRef = { current: el };
+    const onSwipeRight = vi.fn();
+
+    renderHook(() => useSwipeNavigation({ onSwipeRight, elementRef }));
+    act(() => swipeRight(el));
+
+    expect(onSwipeRight).toHaveBeenCalledOnce();
+    document.body.removeChild(el);
+  });
+
+  it('does not call callbacks when disabled is true', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const elementRef = { current: el };
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+
+    renderHook(() => useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef, disabled: true }));
+    act(() => {
+      swipeLeft(el);
+      swipeRight(el);
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+
+  it('does not call callbacks when touch starts with multiple fingers', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const elementRef = { current: el };
+    const onSwipeLeft = vi.fn();
+
+    renderHook(() => useSwipeNavigation({ onSwipeLeft, elementRef }));
+    act(() => {
+      const t1 = makeTouchLike(200, 100);
+      const t2 = makeTouchLike(250, 150);
+      const end = makeTouchLike(80, 100);
+      dispatchTouch(el, 'touchstart', [t1, t2]);
+      dispatchTouch(el, 'touchmove', [end, t2]);
+      dispatchTouch(el, 'touchend', [], [end]);
+      el.dispatchEvent(new Event('transitionend', { bubbles: false }));
+    });
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+
+  it('cleans up event listeners on unmount', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const elementRef = { current: el };
+    const onSwipeLeft = vi.fn();
+
+    const { unmount } = renderHook(() => useSwipeNavigation({ onSwipeLeft, elementRef }));
+    unmount();
+    act(() => swipeLeft(el));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    document.body.removeChild(el);
+  });
+});

--- a/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
+++ b/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
@@ -7,9 +7,10 @@ export interface SwipeNavigationConfig {
   onSwipeLeft?: () => void;
   onSwipeRight?: () => void;
   elementRef: React.RefObject<HTMLElement | null>;
+  disabled?: boolean;
 }
 
-export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef }: SwipeNavigationConfig): void {
+export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef, disabled }: SwipeNavigationConfig): void {
   const touchStartX = useRef<number | null>(null);
   const touchStartY = useRef<number | null>(null);
   const isHorizontalSwipe = useRef<boolean | null>(null);
@@ -17,13 +18,17 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef }: Sw
   // Use refs for callbacks so handlers don't need to be recreated when prev/next changes
   const onSwipeLeftRef = useRef(onSwipeLeft);
   const onSwipeRightRef = useRef(onSwipeRight);
+  const disabledRef = useRef(disabled);
 
   useEffect(() => {
     onSwipeLeftRef.current = onSwipeLeft;
     onSwipeRightRef.current = onSwipeRight;
-  }, [onSwipeLeft, onSwipeRight]);
+    disabledRef.current = disabled;
+  }, [onSwipeLeft, onSwipeRight, disabled]);
 
   const handleTouchStart = useCallback((event: TouchEvent) => {
+    if (disabledRef.current || event.touches.length > 1) return;
+
     const touch = event.touches[0];
     touchStartX.current = touch.clientX;
     touchStartY.current = touch.clientY;
@@ -34,6 +39,7 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef }: Sw
   }, [elementRef]);
 
   const handleTouchMove = useCallback((event: TouchEvent) => {
+    if (disabledRef.current || event.touches.length > 1) return;
     if (touchStartX.current === null || touchStartY.current === null) return;
 
     const touch = event.touches[0];
@@ -57,6 +63,12 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef }: Sw
   }, [elementRef]);
 
   const handleTouchEnd = useCallback((event: TouchEvent) => {
+    if (disabledRef.current) {
+      touchStartX.current = null;
+      touchStartY.current = null;
+      isHorizontalSwipe.current = null;
+      return;
+    }
     if (touchStartX.current === null || touchStartY.current === null || isHorizontalSwipe.current !== true) {
       touchStartX.current = null;
       touchStartY.current = null;

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
+import type { ReactZoomPanPinchContentRef } from 'react-zoom-pan-pinch';
 import { getPhotoByCode, getPhotoImageUrl, getAllPhotos } from '../api/client';
 import type { PhotoDto } from '../api/types';
 import { ChevronLeftIcon, DownloadIcon, ShareIcon, DotsVerticalIcon, SpinnerIcon } from '../components/Icons';
@@ -21,10 +23,12 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
   const [error, setError] = useState<string | null>(code ? null : t('photoNotFoundError'));
   const [allCodes, setAllCodes] = useState<string[]>([]);
   const [photoAction, setPhotoAction] = useState<PhotoAction>('idle');
+  const [isZoomed, setIsZoomed] = useState(false);
   const cachedBlob = useRef<Blob | null>(null);
   const speedDialRef = useRef<HTMLDivElement>(null);
   const canShare = !!(navigator.canShare && navigator.canShare({ files: [new File([''], 'test.jpg', { type: 'image/jpeg' })] }));
   const pageRef = useRef<HTMLDivElement>(null);
+  const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
 
   useEffect(() => {
     if (!code) return;
@@ -53,6 +57,8 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
       pageRef.current.style.transition = 'none';
       pageRef.current.style.transform = '';
     }
+    transformRef.current?.resetTransform(0);
+    setIsZoomed(false);
   }, [code]);
 
   // Reset speed dial state when navigating to a different photo
@@ -89,7 +95,7 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
     if (prevCode) navigate(`/${urlPrefix}/photo/${prevCode}`);
   }, [prevCode, navigate, urlPrefix]);
 
-  useSwipeNavigation({ onSwipeLeft: handleSwipeLeft, onSwipeRight: handleSwipeRight, elementRef: pageRef });
+  useSwipeNavigation({ onSwipeLeft: handleSwipeLeft, onSwipeRight: handleSwipeRight, elementRef: pageRef, disabled: isZoomed });
 
   const handleToggle = async () => {
     if (photoAction === 'expanded') {
@@ -170,11 +176,25 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
     <div className="photo-detail-page" ref={pageRef}>
       {navBar}
       <div className="photo-detail-content">
-        <img
-          src={getPhotoImageUrl(photo.id, 1200)}
-          alt={`Photo ${photo.code}`}
-          className="photo-detail-image"
-        />
+        <TransformWrapper
+          ref={transformRef}
+          minScale={1}
+          maxScale={4}
+          doubleClick={{ disabled: true }}
+          wheel={{ step: 0.2 }}
+          onTransform={(_ref, state) => setIsZoomed(state.scale > 1)}
+        >
+          <TransformComponent
+            wrapperClass="photo-detail-zoom-wrapper"
+            contentClass="photo-detail-zoom-content"
+          >
+            <img
+              src={getPhotoImageUrl(photo.id, 1200)}
+              alt={`Photo ${photo.code}`}
+              className="photo-detail-image"
+            />
+          </TransformComponent>
+        </TransformWrapper>
       </div>
       <div className="photo-detail-actions">
         <div className={`speed-dial${photoAction === 'expanded' ? ' open' : ''}`} ref={speedDialRef}>

--- a/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
 import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
 import { PhotoDetailPage } from '../PhotoDetailPage';
 import type { PhotoDto } from '../../api/types';
@@ -23,8 +24,14 @@ vi.mock('../../api/client', () => ({
   getAllPhotos: () => mockGetAllPhotos(),
 }));
 
+const swipeConfigSpy = vi.fn();
 vi.mock('../../hooks/useSwipeNavigation', () => ({
-  useSwipeNavigation: () => {},
+  useSwipeNavigation: (config: unknown) => swipeConfigSpy(config),
+}));
+
+vi.mock('react-zoom-pan-pinch', () => ({
+  TransformWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TransformComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('../../i18n/useTranslation', () => ({
@@ -53,6 +60,7 @@ describe('PhotoDetailPage', () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({ code: '42' });
     mockNavigate.mockClear();
+    swipeConfigSpy.mockClear();
     mockGetPhotoByCode.mockResolvedValue(mockPhoto);
     mockGetAllPhotos.mockResolvedValue([mockPhoto]);
   });
@@ -171,6 +179,13 @@ describe('PhotoDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Share Photo' })).toBeInTheDocument();
     });
+  });
+
+  it('passes disabled: false to useSwipeNavigation on initial render', async () => {
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    const lastCall = swipeConfigSpy.mock.calls[swipeConfigSpy.mock.calls.length - 1][0];
+    expect(lastCall.disabled).toBe(false);
   });
 
   it('hides share button when navigator.canShare is false', async () => {


### PR DESCRIPTION
Adds pinch-to-zoom (touch), mouse wheel zoom (desktop), and pan-when-zoomed to the photo detail page.

## Changes

- Adds `react-zoom-pan-pinch` dependency (well-established library, accepted as exception to the minimize-deps policy)
- Wraps the detail image in `TransformWrapper`/`TransformComponent` with min 1x, max 4x scale, double-tap disabled
- Swipe-to-navigate is disabled while zoomed (scale > 1) and re-enabled when pinching back to 1x
- Zoom resets automatically when navigating to a different photo
- Extends `useSwipeNavigation` with a `disabled` flag and early-return for multi-touch events (prevents swipe handler from interfering with pinch)
- Adds unit tests for `useSwipeNavigation` (swipe left/right, disabled flag, multi-touch skip, cleanup on unmount)

Closes #221