### PR TITLE
feat: add prev/next arrows and fix swipe-navigation flash on photo detail page

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -408,6 +408,44 @@ body {
   object-fit: contain;
 }
 
+.photo-detail-nav-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  cursor: pointer;
+  z-index: 1;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.photo-detail-nav-arrow.prev {
+  left: 0.5rem;
+}
+
+.photo-detail-nav-arrow.next {
+  right: 0.5rem;
+}
+
+.photo-detail-nav-arrow:hover {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.photo-detail-nav-arrow:active {
+  opacity: 0.6;
+}
+
+.photo-detail-nav-arrow:focus {
+  outline: none;
+}
+
 .photo-detail-loading {
   color: #666;
   font-size: 1.25rem;

--- a/src/PhotoBooth.Web/src/components/Icons.tsx
+++ b/src/PhotoBooth.Web/src/components/Icons.tsx
@@ -96,6 +96,24 @@ export function SpinnerIcon({ size = 24, className }: IconProps) {
   );
 }
 
+export function ChevronRightIcon({ size = 24, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
 export function SearchIcon({ size = 24, className }: IconProps) {
   return (
     <svg

--- a/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
+++ b/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
@@ -93,9 +93,9 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef, disa
       el.style.transition = `transform ${SLIDE_DURATION_MS}ms ease`;
       el.style.transform = `translateX(${targetOffset}px)`;
       el.addEventListener('transitionend', () => {
+        callback();
         el.style.transition = 'none';
         el.style.transform = '';
-        callback();
       }, { once: true });
     } else {
       el.style.transition = `transform ${SLIDE_DURATION_MS}ms ease`;

--- a/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
+++ b/src/PhotoBooth.Web/src/hooks/useSwipeNavigation.ts
@@ -57,6 +57,7 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef, disa
     if (!canSwipe) return;
 
     event.preventDefault();
+    event.stopPropagation();
 
     const el = elementRef.current;
     if (el) el.style.transform = `translateX(${deltaX}px)`;
@@ -109,14 +110,14 @@ export function useSwipeNavigation({ onSwipeLeft, onSwipeRight, elementRef, disa
     const element = elementRef.current;
     if (!element) return;
 
-    element.addEventListener('touchstart', handleTouchStart, { passive: true });
-    element.addEventListener('touchmove', handleTouchMove, { passive: false });
-    element.addEventListener('touchend', handleTouchEnd, { passive: true });
+    element.addEventListener('touchstart', handleTouchStart, { passive: true, capture: true });
+    element.addEventListener('touchmove', handleTouchMove, { passive: false, capture: true });
+    element.addEventListener('touchend', handleTouchEnd, { passive: true, capture: true });
 
     return () => {
-      element.removeEventListener('touchstart', handleTouchStart);
-      element.removeEventListener('touchmove', handleTouchMove);
-      element.removeEventListener('touchend', handleTouchEnd);
+      element.removeEventListener('touchstart', handleTouchStart, { capture: true });
+      element.removeEventListener('touchmove', handleTouchMove, { capture: true });
+      element.removeEventListener('touchend', handleTouchEnd, { capture: true });
       element.style.transform = '';
       element.style.transition = '';
     };

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -16,6 +16,8 @@ export const translations = {
     loading: 'Loading...',
     photoNotFoundError: 'Photo not found',
     backToGallery: 'Back to Gallery',
+    previousPhoto: 'Previous photo',
+    nextPhoto: 'Next photo',
 
     // Slideshow
     noPhotosToShow: 'No photos to show yet',
@@ -41,6 +43,8 @@ export const translations = {
     loading: 'Cargando...',
     photoNotFoundError: 'Foto no encontrada',
     backToGallery: 'Volver a la Galería',
+    previousPhoto: 'Foto anterior',
+    nextPhoto: 'Foto siguiente',
 
     // Slideshow
     noPhotosToShow: 'Aún no hay fotos para mostrar',

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { flushSync } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import type { ReactZoomPanPinchContentRef } from 'react-zoom-pan-pinch';
@@ -88,9 +89,11 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
   const nextCode = currentIndex >= 0 && currentIndex < allCodes.length - 1 ? allCodes[currentIndex + 1] : null;
 
   const goToPhoto = useCallback((targetCode: string) => {
-    setPhoto(null);
-    setLoading(true);
-    setError(null);
+    flushSync(() => {
+      setPhoto(null);
+      setLoading(true);
+      setError(null);
+    });
     navigate(`/${urlPrefix}/photo/${targetCode}`);
   }, [navigate, urlPrefix]);
 

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -4,7 +4,7 @@ import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import type { ReactZoomPanPinchContentRef } from 'react-zoom-pan-pinch';
 import { getPhotoByCode, getPhotoImageUrl, getAllPhotos } from '../api/client';
 import type { PhotoDto } from '../api/types';
-import { ChevronLeftIcon, DownloadIcon, ShareIcon, DotsVerticalIcon, SpinnerIcon } from '../components/Icons';
+import { ChevronLeftIcon, ChevronRightIcon, DownloadIcon, ShareIcon, DotsVerticalIcon, SpinnerIcon } from '../components/Icons';
 import { useTranslation } from '../i18n/useTranslation';
 import { useSwipeNavigation } from '../hooks/useSwipeNavigation';
 
@@ -87,13 +87,20 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
   const prevCode = currentIndex > 0 ? allCodes[currentIndex - 1] : null;
   const nextCode = currentIndex >= 0 && currentIndex < allCodes.length - 1 ? allCodes[currentIndex + 1] : null;
 
+  const goToPhoto = useCallback((targetCode: string) => {
+    setPhoto(null);
+    setLoading(true);
+    setError(null);
+    navigate(`/${urlPrefix}/photo/${targetCode}`);
+  }, [navigate, urlPrefix]);
+
   const handleSwipeLeft = useCallback(() => {
-    if (nextCode) navigate(`/${urlPrefix}/photo/${nextCode}`);
-  }, [nextCode, navigate, urlPrefix]);
+    if (nextCode) goToPhoto(nextCode);
+  }, [nextCode, goToPhoto]);
 
   const handleSwipeRight = useCallback(() => {
-    if (prevCode) navigate(`/${urlPrefix}/photo/${prevCode}`);
-  }, [prevCode, navigate, urlPrefix]);
+    if (prevCode) goToPhoto(prevCode);
+  }, [prevCode, goToPhoto]);
 
   useSwipeNavigation({ onSwipeLeft: handleSwipeLeft, onSwipeRight: handleSwipeRight, elementRef: pageRef, disabled: isZoomed });
 
@@ -176,6 +183,24 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
     <div className="photo-detail-page" ref={pageRef}>
       {navBar}
       <div className="photo-detail-content">
+        {!isZoomed && prevCode && (
+          <button
+            onClick={() => goToPhoto(prevCode)}
+            className="photo-detail-nav-arrow prev"
+            aria-label={t('previousPhoto')}
+          >
+            <ChevronLeftIcon size={28} />
+          </button>
+        )}
+        {!isZoomed && nextCode && (
+          <button
+            onClick={() => goToPhoto(nextCode)}
+            className="photo-detail-nav-arrow next"
+            aria-label={t('nextPhoto')}
+          >
+            <ChevronRightIcon size={28} />
+          </button>
+        )}
         <TransformWrapper
           ref={transformRef}
           minScale={1}
@@ -189,6 +214,7 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
             contentClass="photo-detail-zoom-content"
           >
             <img
+              key={photo.id}
               src={getPhotoImageUrl(photo.id, 1200)}
               alt={`Photo ${photo.code}`}
               className="photo-detail-image"

--- a/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
@@ -29,8 +29,14 @@ vi.mock('../../hooks/useSwipeNavigation', () => ({
   useSwipeNavigation: (config: unknown) => swipeConfigSpy(config),
 }));
 
+type OnTransformFn = (ref: unknown, state: { scale: number }) => void;
+let capturedOnTransform: OnTransformFn | undefined;
+
 vi.mock('react-zoom-pan-pinch', () => ({
-  TransformWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TransformWrapper: ({ children, onTransform }: { children: React.ReactNode; onTransform?: OnTransformFn }) => {
+    capturedOnTransform = onTransform;
+    return <>{children}</>;
+  },
   TransformComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
@@ -44,6 +50,8 @@ vi.mock('../../i18n/useTranslation', () => ({
         getPhoto: 'Get Photo',
         downloadPhoto: 'Download Photo',
         sharePhoto: 'Share Photo',
+        previousPhoto: 'Previous photo',
+        nextPhoto: 'Next photo',
       };
       return map[key] ?? key;
     },
@@ -56,11 +64,24 @@ const mockPhoto: PhotoDto = {
   capturedAt: '2025-01-01T00:00:00Z',
 };
 
+const mockPrevPhoto: PhotoDto = {
+  id: 'photo-prev',
+  code: '41',
+  capturedAt: '2025-01-01T00:00:00Z',
+};
+
+const mockNextPhoto: PhotoDto = {
+  id: 'photo-next',
+  code: '43',
+  capturedAt: '2025-01-01T00:00:00Z',
+};
+
 describe('PhotoDetailPage', () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({ code: '42' });
     mockNavigate.mockClear();
     swipeConfigSpy.mockClear();
+    capturedOnTransform = undefined;
     mockGetPhotoByCode.mockResolvedValue(mockPhoto);
     mockGetAllPhotos.mockResolvedValue([mockPhoto]);
   });
@@ -210,5 +231,86 @@ describe('PhotoDetailPage', () => {
       expect(screen.getByRole('button', { name: 'Download Photo' })).toBeInTheDocument();
     });
     expect(screen.queryByRole('button', { name: 'Share Photo' })).not.toBeInTheDocument();
+  });
+
+  it('shows loading state when clicking next arrow (goToPhoto resets state before navigation)', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    // clicking next calls goToPhoto which synchronously sets loading=true and photo=null
+    // before calling navigate (which is a spy here and won't change the route)
+    fireEvent.click(screen.getByRole('button', { name: 'Next photo' }));
+
+    // after the click, loading state should be shown because photo was cleared
+    await waitFor(() => expect(screen.getByText('Loading...')).toBeInTheDocument());
+  });
+
+  it('renders prev and next nav arrow buttons when neighbours exist', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    expect(screen.getByRole('button', { name: 'Previous photo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next photo' })).toBeInTheDocument();
+  });
+
+  it('clicking next arrow navigates to the next photo', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next photo' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/testprefix/photo/43');
+  });
+
+  it('clicking prev arrow navigates to the previous photo', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous photo' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/testprefix/photo/41');
+  });
+
+  it('hides prev arrow when at the first photo', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: 'Previous photo' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next photo' })).toBeInTheDocument();
+  });
+
+  it('hides next arrow when at the last photo', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    expect(screen.getByRole('button', { name: 'Previous photo' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next photo' })).not.toBeInTheDocument();
+  });
+
+  it('hides nav arrows when zoomed', async () => {
+    mockGetAllPhotos.mockResolvedValue([mockPrevPhoto, mockPhoto, mockNextPhoto]);
+
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    // arrows visible before zoom
+    expect(screen.getByRole('button', { name: 'Previous photo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next photo' })).toBeInTheDocument();
+
+    // trigger zoom via the onTransform callback captured by the TransformWrapper mock
+    await act(async () => { capturedOnTransform?.(null, { scale: 2 }); });
+
+    expect(screen.queryByRole('button', { name: 'Previous photo' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next photo' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- **Fix swipe glitch**: Added `goToPhoto()` helper that clears `photo` and `loading` state synchronously before calling `navigate()`. This ensures the next render shows the loading screen instead of a flash of the previous photo after the swipe-out animation completes.
- **Fix image blink**: Added `key={photo.id}` to the img element so React unmounts the previous DOM node rather than reusing it, preventing the cached bitmap from lingering during decode.
- **Prev/next buttons**: Added semi-transparent overlay chevron buttons at the left and right edges of the photo, vertically centred. Hidden when zoomed or at the first/last photo. Reuse `goToPhoto()` for the same flash-free transition as swipe.
- **New icon**: Added `ChevronRightIcon` to `Icons.tsx`.
- **i18n**: Added `previousPhoto` / `nextPhoto` keys for `en` and `es`.
- **Tests**: Added tests for arrow rendering, click navigation, boundary hiding, zoom hiding, and loading-state reset.

## Test plan

- [ ] Swipe left/right in Chrome DevTools device emulation: page slides off, brief loading screen, new photo with no flash of old photo
- [ ] Click right/left chevron on desktop: navigates cleanly
- [ ] Pinch/wheel-zoom in: both chevrons disappear; reset zoom: chevrons reappear
- [ ] First photo: no left chevron; last photo: no right chevron
- [ ] pnpm test: all 136 tests green

Closes #220