### PR TITLE
Remember gallery scroll position when navigating back

### DIFF
--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -23,6 +23,16 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   const [error, setError] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null | undefined>(hasCachedPhotos ? cached.nextCursor : undefined);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  // Tracks scroll position continuously so the unmount cleanup reads the gallery's
+  // scroll, not the next page's (cleanup fires after DOM commit)
+  const scrollTopRef = useRef(initialScrollTop);
+
+  // Keep scrollTopRef current while the gallery is mounted
+  useEffect(() => {
+    const onScroll = () => { scrollTopRef.current = window.scrollY; };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   // Restore scroll position once after hydrating from cache, before paint
   useLayoutEffect(() => {
@@ -51,7 +61,7 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   // the cleanup closure always captures the latest values
   useEffect(() => {
     return () => {
-      setGalleryCache(photos, nextCursor, window.scrollY);
+      setGalleryCache(photos, nextCursor, scrollTopRef.current);
     };
   }, [photos, nextCursor]);
 

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -110,7 +110,7 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
         <div
           key={photo.id}
           className="photo-grid-item"
-          onClick={() => onPhotoClick(photo.code)}
+          onClick={() => { scrollTopRef.current = window.scrollY; onPhotoClick(photo.code); }}
         >
           <img
             src={getPhotoImageUrl(photo.id, 400)}

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -23,11 +23,13 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   const [error, setError] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null | undefined>(hasCachedPhotos ? cached.nextCursor : undefined);
   const sentinelRef = useRef<HTMLDivElement>(null);
-  // Tracks scroll position continuously so the unmount cleanup reads the gallery's
-  // scroll, not the next page's (cleanup fires after DOM commit)
+  // Updated by the scroll listener while the gallery is mounted
   const scrollTopRef = useRef(initialScrollTop);
+  // Set to true when a tile is clicked; the onClick saves to cache at that moment,
+  // so the unmount cleanup should not overwrite it (the scroll event fired during
+  // page transition can clamp window.scrollY to 0, corrupting scrollTopRef)
+  const savedViaClickRef = useRef(false);
 
-  // Keep scrollTopRef current while the gallery is mounted
   useEffect(() => {
     const onScroll = () => { scrollTopRef.current = window.scrollY; };
     window.addEventListener('scroll', onScroll, { passive: true });
@@ -57,11 +59,14 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Save to cache on unmount; re-registers whenever photos/nextCursor change so
-  // the cleanup closure always captures the latest values
+  // Save to cache on unmount, unless a tile click already saved it — in that case
+  // the click-time value is correct and scrollTopRef may have been clamped to 0
+  // by a browser scroll event fired during the page transition
   useEffect(() => {
     return () => {
-      setGalleryCache(photos, nextCursor, scrollTopRef.current);
+      if (!savedViaClickRef.current) {
+        setGalleryCache(photos, nextCursor, scrollTopRef.current);
+      }
     };
   }, [photos, nextCursor]);
 
@@ -110,7 +115,11 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
         <div
           key={photo.id}
           className="photo-grid-item"
-          onClick={() => { scrollTopRef.current = window.scrollY; onPhotoClick(photo.code); }}
+          onClick={() => {
+            setGalleryCache(photos, nextCursor, window.scrollY);
+            savedViaClickRef.current = true;
+            onPhotoClick(photo.code);
+          }}
         >
           <img
             src={getPhotoImageUrl(photo.id, 400)}

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 import { getPhotosPage, getPhotoImageUrl } from '../api/client';
 import type { PhotoDto } from '../api/types';
 import { useTranslation } from '../i18n/useTranslation';
+import { getGalleryCache, setGalleryCache } from './galleryCache';
 
 const PAGE_SIZE = 30;
 
@@ -11,14 +12,30 @@ interface PhotoGridProps {
 
 export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   const { t } = useTranslation();
-  const [photos, setPhotos] = useState<PhotoDto[]>([]);
-  const [loading, setLoading] = useState(true);
+
+  const cached = getGalleryCache();
+  const hasCachedPhotos = cached.photos !== null && cached.photos.length > 0;
+  const initialScrollTop = cached.scrollTop;
+
+  const [photos, setPhotos] = useState<PhotoDto[]>(hasCachedPhotos ? cached.photos! : []);
+  const [loading, setLoading] = useState(!hasCachedPhotos);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [nextCursor, setNextCursor] = useState<string | null | undefined>(undefined);
+  const [nextCursor, setNextCursor] = useState<string | null | undefined>(hasCachedPhotos ? cached.nextCursor : undefined);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
+  // Restore scroll position once after hydrating from cache, before paint
+  useLayoutEffect(() => {
+    if (hasCachedPhotos) {
+      window.scrollTo(0, initialScrollTop);
+    }
+    // intentionally runs only once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Initial fetch, skipped when hydrating from cache
   useEffect(() => {
+    if (hasCachedPhotos) return;
     getPhotosPage(PAGE_SIZE)
       .then(page => {
         setPhotos(page.photos);
@@ -26,7 +43,17 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
       })
       .catch(err => setError(err instanceof Error ? err.message : t('failedToLoadPhotos')))
       .finally(() => setLoading(false));
-  }, [t]);
+    // intentionally runs only once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Save to cache on unmount; re-registers whenever photos/nextCursor change so
+  // the cleanup closure always captures the latest values
+  useEffect(() => {
+    return () => {
+      setGalleryCache(photos, nextCursor, window.scrollY);
+    };
+  }, [photos, nextCursor]);
 
   const loadMore = useCallback(() => {
     if (!nextCursor || loadingMore) return;

--- a/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
+++ b/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { PhotoGrid } from '../PhotoGrid';
+import { getGalleryCache, setGalleryCache, __resetForTests } from '../galleryCache';
+import type { PhotoDto } from '../../api/types';
+
+const mockGetPhotosPage = vi.fn<(pageSize: number, cursor?: string) => Promise<{ photos: PhotoDto[]; nextCursor: string | null }>>();
+
+vi.mock('../../api/client', () => ({
+  getPhotosPage: (pageSize: number, cursor?: string) => mockGetPhotosPage(pageSize, cursor),
+  getPhotoImageUrl: (photoId: string, width?: number) => {
+    const base = `/api/photos/${photoId}/image`;
+    return width !== undefined ? `${base}?width=${width}` : base;
+  },
+}));
+
+vi.mock('../../i18n/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        loadingPhotos: 'Loading photos...',
+        failedToLoadPhotos: 'Failed to load photos',
+        noPhotosYet: 'No photos yet',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+class MockIntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {}
+}
+
+const samplePhotos: PhotoDto[] = [
+  { id: 'id-1', code: '1', capturedAt: '2024-01-01T00:00:00Z' },
+  { id: 'id-2', code: '2', capturedAt: '2024-01-02T00:00:00Z' },
+];
+
+describe('PhotoGrid', () => {
+  beforeEach(() => {
+    __resetForTests();
+    mockGetPhotosPage.mockClear();
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and renders photos on first mount when cache is empty', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: null });
+
+    render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    expect(mockGetPhotosPage).toHaveBeenCalledOnce();
+  });
+
+  it('renders cached photos without fetching when cache is populated', () => {
+    setGalleryCache(samplePhotos, null, 0);
+
+    render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    expect(screen.getAllByRole('img')).toHaveLength(2);
+    expect(mockGetPhotosPage).not.toHaveBeenCalled();
+  });
+
+  it('saves photos, nextCursor, and scrollY to cache on unmount', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: 'cursor-abc' });
+
+    const { unmount } = render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    unmount();
+
+    const cache = getGalleryCache();
+    expect(cache.photos).toEqual(samplePhotos);
+    expect(cache.nextCursor).toBe('cursor-abc');
+    expect(typeof cache.scrollTop).toBe('number');
+  });
+
+  it('restores scroll position from cache on hydrated mount', () => {
+    setGalleryCache(samplePhotos, null, 500);
+
+    render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 500);
+  });
+
+  it('does not restore scroll when cache is empty', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: null });
+
+    render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('calls onPhotoClick with the photo code when a tile is clicked', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: null });
+    const onPhotoClick = vi.fn();
+
+    render(<PhotoGrid onPhotoClick={onPhotoClick} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    screen.getAllByRole('img')[0].closest('.photo-grid-item')!.dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    );
+
+    expect(onPhotoClick).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
+++ b/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
@@ -31,7 +31,7 @@ class MockIntersectionObserver {
   observe = vi.fn();
   disconnect = vi.fn();
   unobserve = vi.fn();
-  constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {}
+  constructor() {}
 }
 
 const samplePhotos: PhotoDto[] = [

--- a/src/PhotoBooth.Web/src/components/galleryCache.ts
+++ b/src/PhotoBooth.Web/src/components/galleryCache.ts
@@ -22,6 +22,10 @@ export function setGalleryCache(photos: PhotoDto[], nextCursor: string | null | 
   cache.scrollTop = scrollTop;
 }
 
+export function hasGalleryCache(): boolean {
+  return cache.photos !== null && cache.photos.length > 0;
+}
+
 export function clearGalleryCache(): void {
   cache.photos = null;
   cache.nextCursor = undefined;

--- a/src/PhotoBooth.Web/src/components/galleryCache.ts
+++ b/src/PhotoBooth.Web/src/components/galleryCache.ts
@@ -1,0 +1,33 @@
+import type { PhotoDto } from '../api/types';
+
+interface GalleryCache {
+  photos: PhotoDto[] | null;
+  nextCursor: string | null | undefined;
+  scrollTop: number;
+}
+
+const cache: GalleryCache = {
+  photos: null,
+  nextCursor: undefined,
+  scrollTop: 0,
+};
+
+export function getGalleryCache(): Readonly<GalleryCache> {
+  return cache;
+}
+
+export function setGalleryCache(photos: PhotoDto[], nextCursor: string | null | undefined, scrollTop: number): void {
+  cache.photos = photos;
+  cache.nextCursor = nextCursor;
+  cache.scrollTop = scrollTop;
+}
+
+export function clearGalleryCache(): void {
+  cache.photos = null;
+  cache.nextCursor = undefined;
+  cache.scrollTop = 0;
+}
+
+export function __resetForTests(): void {
+  clearGalleryCache();
+}

--- a/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/DownloadPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { PhotoGrid } from '../components/PhotoGrid';
 import { SearchIcon } from '../components/Icons';
 import { useTranslation } from '../i18n/useTranslation';
+import { hasGalleryCache } from '../components/galleryCache';
 
 interface DownloadPageProps {
   urlPrefix: string;
@@ -36,7 +37,7 @@ export function DownloadPage({ urlPrefix }: DownloadPageProps) {
           className="code-input"
           maxLength={10}
           inputMode="numeric"
-          autoFocus
+          autoFocus={!hasGalleryCache()}
         />
         <button type="submit" disabled={!code.trim()} className="search-button" aria-label={t('findPhoto')}>
           <SearchIcon size={20} />


### PR DESCRIPTION
## Summary

- Adds an in-memory gallery cache () that stores the loaded photos, pagination cursor, and scroll position
-  hydrates from cache on mount (skipping the initial fetch) and restores scroll via 
- Scroll is saved synchronously in the tile click handler — before browser scroll events can clamp  to 0 during the page transition
-  on the search input is suppressed when returning to a cached gallery, preventing it from scrolling back to top

Closes #219