### PR TITLE
feat: add integration load test for guest photo gallery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,8 +181,8 @@ dotnet test tests/PhotoBooth.Server.Tests --filter "FullyQualifiedName~GuestLoad
 
 **Environment variables** (all optional):
 - `LOADTEST_TARGET_USERS` — total virtual users across all scenarios (default: 50)
-- `LOADTEST_PHOTO_COUNT` — photos seeded to a temp directory (default: 50)
-- `LOADTEST_DURATION_MIN` — hold-phase duration in minutes (default: 3)
+- `LOADTEST_PHOTO_COUNT` — photos seeded to a temp directory (default: 20)
+- `LOADTEST_DURATION_MIN` — hold-phase duration in minutes (default: 1)
 
 **Find the concurrent-user limit:** increase `LOADTEST_TARGET_USERS` until the `gallery_browse` p95 latency (after subtracting the 100ms simulated RTT baseline) exceeds ~2s, or the error rate exceeds 1%. The last clean value is the answer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,9 +176,7 @@ Uses **NBomber 6.x** with an in-process TestServer (not real Kestrel — all ser
 
 **Run:**
 ```bash
-dotnet test tests/PhotoBooth.Server.Tests \
-  --filter "FullyQualifiedName~GuestLoadTests" \
-  --logger "console;verbosity=detailed"
+dotnet test tests/PhotoBooth.Server.Tests --filter "FullyQualifiedName~GuestLoadTests" --logger "console;verbosity=detailed"
 ```
 
 **Environment variables** (all optional):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,30 @@ dotnet build installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj --confi
 
 The version is extracted from the git tag in the release workflow (strips `v` prefix and semver prerelease/build metadata).
 
+## Load Testing
+
+`tests/PhotoBooth.Server.Tests/GuestLoadTests.cs` — marked `[TestCategory("Integration")]`, skipped in CI.
+
+Uses **NBomber 6.x** with an in-process TestServer (not real Kestrel — all server-side code runs, but Kestrel connection queuing is bypassed). Three scenarios mirror real guest behaviour: `gallery_browse` (60% of VUs), `detail_view` (30%), `download` (10%).
+
+**Run:**
+```bash
+dotnet test tests/PhotoBooth.Server.Tests \
+  --filter "FullyQualifiedName~GuestLoadTests" \
+  --logger "console;verbosity=detailed"
+```
+
+**Environment variables** (all optional):
+- `LOADTEST_TARGET_USERS` — total virtual users across all scenarios (default: 50)
+- `LOADTEST_PHOTO_COUNT` — photos seeded to a temp directory (default: 50)
+- `LOADTEST_DURATION_MIN` — hold-phase duration in minutes (default: 3)
+
+**Find the concurrent-user limit:** increase `LOADTEST_TARGET_USERS` until the `gallery_browse` p95 latency (after subtracting the 100ms simulated RTT baseline) exceeds ~2s, or the error rate exceeds 1%. The last clean value is the answer.
+
+**Bandwidth:** not simulated in-process. Use the analytic ceilings printed in the summary (e.g. at 10 Mbps client / 200 Mbps server) to cross-check results. For high-fidelity bandwidth simulation, run the server with `dotnet run` and apply OS-level shaping (`pfctl` on macOS, `tc` on Linux).
+
+**Report:** HTML and TXT written to `tests/PhotoBooth.Server.Tests/bin/Debug/net10.0/load-reports/<timestamp>/`.
+
 ## Reference
 
 - **SPEC.md**: Functional specification - describes how the application should work. Consult this for requirements and intended behavior.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <!-- Load Testing -->
+    <PackageVersion Include="NBomber" Version="6.3.0" />
     <!-- Testing -->
     <PackageVersion Include="MSTest" Version="4.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -70,6 +71,14 @@ public sealed class GuestLoadTests
                         ["Trigger:RestrictToLocalhost"] = "false",
                         ["Watchdog:ServerInactivityMinutes"] = "0"
                     });
+                });
+                // Program.cs sets the static Serilog logger (WriteTo.Console at Info) before
+                // ConfigureAppConfiguration overrides run, so suppress it here instead.
+                builder.ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddConsole();
+                    logging.SetMinimumLevel(LogLevel.Warning);
                 });
                 builder.ConfigureServices(services =>
                 {

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -35,8 +35,8 @@ namespace PhotoBooth.Server.Tests;
 //
 // ENVIRONMENT VARIABLES
 //   LOADTEST_TARGET_USERS  – total virtual users across all scenarios (default 50)
-//   LOADTEST_PHOTO_COUNT   – photos to seed into temp storage (default 50)
-//   LOADTEST_DURATION_MIN  – hold-phase duration in minutes (default 3)
+//   LOADTEST_PHOTO_COUNT   – photos to seed into temp storage (default 20)
+//   LOADTEST_DURATION_MIN  – hold-phase duration in minutes (default 1)
 [TestClass]
 [TestCategory("Integration")]
 public sealed class GuestLoadTests
@@ -51,7 +51,7 @@ public sealed class GuestLoadTests
     public static void ClassInit(TestContext testContext)
     {
         var photoCount = int.Parse(
-            Environment.GetEnvironmentVariable("LOADTEST_PHOTO_COUNT") ?? "50");
+            Environment.GetEnvironmentVariable("LOADTEST_PHOTO_COUNT") ?? "20");
 
         testContext.WriteLine($"Seeding {photoCount} photos...");
         _seeded = PhotoSeeder.Seed(photoCount);
@@ -129,7 +129,7 @@ public sealed class GuestLoadTests
     public void RunGuestLoadScenario()
     {
         var targetVUs   = int.Parse(Environment.GetEnvironmentVariable("LOADTEST_TARGET_USERS")  ?? "50");
-        var holdMinutes = int.Parse(Environment.GetEnvironmentVariable("LOADTEST_DURATION_MIN")  ?? "3");
+        var holdMinutes = int.Parse(Environment.GetEnvironmentVariable("LOADTEST_DURATION_MIN")  ?? "1");
 
         var photos = _seeded.Photos;
 
@@ -257,8 +257,8 @@ public sealed class GuestLoadTests
         });
 
         return Scenario.WithLoadSimulations(scenario, [
-            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(30)),
-            Simulation.RampingConstant(vus, TimeSpan.FromMinutes(2)),
+            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(15)),
+            Simulation.RampingConstant(vus, TimeSpan.FromSeconds(30)),
             Simulation.KeepConstant(vus, TimeSpan.FromMinutes(holdMinutes))
         ]);
     }
@@ -306,8 +306,8 @@ public sealed class GuestLoadTests
         });
 
         return Scenario.WithLoadSimulations(scenario, [
-            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(30)),
-            Simulation.RampingConstant(vus, TimeSpan.FromMinutes(2)),
+            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(15)),
+            Simulation.RampingConstant(vus, TimeSpan.FromSeconds(30)),
             Simulation.KeepConstant(vus, TimeSpan.FromMinutes(holdMinutes))
         ]);
     }

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -26,9 +26,7 @@ namespace PhotoBooth.Server.Tests;
 //   Bandwidth: not simulated in-process; see analytic ceiling in test output.
 //
 // HOW TO RUN
-//   dotnet test tests/PhotoBooth.Server.Tests \
-//     --filter "FullyQualifiedName~GuestLoadTests" \
-//     --logger "console;verbosity=detailed"
+//   dotnet test tests/PhotoBooth.Server.Tests --filter "FullyQualifiedName~GuestLoadTests" --logger "console;verbosity=detailed"
 //
 // ENVIRONMENT VARIABLES
 //   LOADTEST_TARGET_USERS  – total virtual users across all scenarios (default 50)

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,16 +71,20 @@ public sealed class GuestLoadTests
                         ["Watchdog:ServerInactivityMinutes"] = "0"
                     });
                 });
-                // Program.cs sets the static Serilog logger (WriteTo.Console at Info) before
-                // ConfigureAppConfiguration overrides run, so suppress it here instead.
-                builder.ConfigureLogging(logging =>
-                {
-                    logging.ClearProviders();
-                    logging.AddConsole();
-                    logging.SetMinimumLevel(LogLevel.Warning);
-                });
                 builder.ConfigureServices(services =>
                 {
+                    // Serilog is registered on IHostBuilder (not IWebHostBuilder), so
+                    // ConfigureLogging on the web host doesn't reach it. Remove its
+                    // ILoggerFactory and replace with a Warning-level one so Info-level
+                    // request logs don't flood the load-test output.
+                    foreach (var d in services.Where(s => s.ServiceType == typeof(ILoggerFactory)).ToList())
+                        services.Remove(d);
+                    services.AddLogging(b =>
+                    {
+                        b.AddConsole();
+                        b.SetMinimumLevel(LogLevel.Warning);
+                    });
+
                     // PhotoStorage:Path is captured as a local variable early in Program.cs
                     // before ConfigureAppConfiguration overrides apply, so the repository and
                     // resizer must be replaced here where the seeded paths are used directly.

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -1,0 +1,370 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NBomber.Contracts;
+using NBomber.Contracts.Stats;
+using NBomber.CSharp;
+using PhotoBooth.Application.DTOs;
+using PhotoBooth.Domain.Entities;
+using PhotoBooth.Server.Tests.LoadTesting;
+
+namespace PhotoBooth.Server.Tests;
+
+// Load test for the guest-facing photo gallery endpoints (issue #223).
+//
+// Uses NBomber with an in-process TestServer (WebApplicationFactory default) rather than real
+// Kestrel. This means Kestrel connection-queuing is not under load, but all server-side work
+// — FileSystemPhotoRepository disk reads, OpenCvImageResizer thumbnail lookups, JSON
+// serialisation, security headers — is exercised identically. The result accurately
+// characterises CPU, memory, and I/O resource consumption.
+//
+// NETWORK SIMULATION
+//   Latency: ~100ms RTT added by LatencyHandler (50ms before send + 50ms after receive).
+//   Bandwidth: not simulated in-process; see analytic ceiling in test output.
+//
+// HOW TO RUN
+//   dotnet test tests/PhotoBooth.Server.Tests \
+//     --filter "FullyQualifiedName~GuestLoadTests" \
+//     --logger "console;verbosity=detailed"
+//
+// ENVIRONMENT VARIABLES
+//   LOADTEST_TARGET_USERS  – total virtual users across all scenarios (default 50)
+//   LOADTEST_PHOTO_COUNT   – photos to seed into temp storage (default 50)
+//   LOADTEST_DURATION_MIN  – hold-phase duration in minutes (default 3)
+[TestClass]
+[TestCategory("Integration")]
+public sealed class GuestLoadTests
+{
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private static SeededPhotos _seeded = null!;
+    private static WebApplicationFactory<Program> _factory = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext testContext)
+    {
+        var photoCount = int.Parse(
+            Environment.GetEnvironmentVariable("LOADTEST_PHOTO_COUNT") ?? "50");
+
+        testContext.WriteLine($"Seeding {photoCount} photos...");
+        _seeded = PhotoSeeder.Seed(photoCount);
+        testContext.WriteLine($"Photos seeded to {_seeded.BasePath}");
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Camera:Provider"] = "mock",
+                        ["PhotoStorage:Path"] = _seeded.BasePath,
+                        ["Event:Name"] = _seeded.EventName,
+                        ["Trigger:RestrictToLocalhost"] = "false",
+                        // Prevent watchdog from shutting down the host mid-test
+                        ["Watchdog:ServerInactivityMinutes"] = "0"
+                    });
+                });
+                builder.ConfigureServices(services =>
+                {
+                    // Photos are pre-warmed by PhotoSeeder; disable background warmup
+                    // so it doesn't compete with load-test requests at startup.
+                    var warmup = services.FirstOrDefault(d =>
+                        d.ServiceType == typeof(IHostedService) &&
+                        d.ImplementationType == typeof(ThumbnailWarmupService));
+                    if (warmup != null) services.Remove(warmup);
+                });
+            });
+
+        // Trigger factory initialisation (creates TestServer, wires DI, loads photos)
+        using var warmupClient = _factory.CreateClient();
+        warmupClient.GetAsync("/api/config").GetAwaiter().GetResult();
+        testContext.WriteLine("Server initialised");
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        _factory?.Dispose();
+        _seeded?.Cleanup();
+    }
+
+    [TestMethod]
+    public void RunGuestLoadScenario()
+    {
+        var targetVUs   = int.Parse(Environment.GetEnvironmentVariable("LOADTEST_TARGET_USERS")  ?? "50");
+        var holdMinutes = int.Parse(Environment.GetEnvironmentVariable("LOADTEST_DURATION_MIN")  ?? "3");
+
+        var photos = _seeded.Photos;
+
+        // Allocate virtual users proportionally to simulate the real visitor mix
+        var galleryVUs  = Math.Max(1, targetVUs * 60 / 100);
+        var detailVUs   = Math.Max(1, targetVUs * 30 / 100);
+        var downloadVUs = Math.Max(1, targetVUs * 10 / 100);
+
+        using var galleryClient  = CreateHttpClient();
+        using var detailClient   = CreateHttpClient();
+        using var downloadClient = CreateHttpClient();
+
+        var galleryScenario  = BuildGalleryBrowseScenario(galleryClient,  photos, galleryVUs,  holdMinutes);
+        var detailScenario   = BuildDetailViewScenario(detailClient,   photos, detailVUs,   holdMinutes);
+        var downloadScenario = BuildDownloadScenario(downloadClient, photos, downloadVUs, holdMinutes);
+
+        var reportFolder = Path.Combine(
+            AppContext.BaseDirectory, "load-reports", DateTime.UtcNow.ToString("yyyyMMdd-HHmmss"));
+
+        var ctx = NBomberRunner.RegisterScenarios([galleryScenario, detailScenario, downloadScenario]);
+        ctx = NBomberRunner.WithTestSuite(ctx, "PhotoBoothGuestLoad");
+        ctx = NBomberRunner.WithTestName(ctx, $"vus-{targetVUs}_photos-{photos.Count}");
+        ctx = NBomberRunner.WithReportFolder(ctx, reportFolder);
+        ctx = NBomberRunner.WithReportFormats(ctx, [ReportFormat.Html, ReportFormat.Txt]);
+
+        var nodeStats = NBomberRunner.Run(ctx);
+
+        PrintSummary(nodeStats, targetVUs, holdMinutes, photos.Count, reportFolder);
+
+        var totalRequests = nodeStats.AllRequestCount;
+        var totalFails    = nodeStats.AllFailCount;
+        var errorRate     = totalRequests > 0 ? (double)totalFails / totalRequests : 0;
+
+        Assert.IsTrue(errorRate < 0.01,
+            $"Error rate {errorRate:P2} exceeded 1% " +
+            $"({totalFails:N0} failures / {totalRequests:N0} requests). " +
+            "The server is returning errors under this load, not just slowing down.");
+    }
+
+    // ── Scenario builders ─────────────────────────────────────────────────────
+
+    // Models a guest opening the gallery and scrolling through a page of photos.
+    // Mirrors PhotoGrid.tsx: fetches /api/photos?limit=30 then requests 30 thumbnails
+    // at width=400 (up to 6 in parallel, matching browser connection limit).
+    private static ScenarioProps BuildGalleryBrowseScenario(
+        HttpClient client, IReadOnlyList<Photo> photos, int vus, int holdMinutes)
+    {
+        var scenario = Scenario.Create("gallery_browse", async context =>
+        {
+            try
+            {
+                // Initial config fetch (once per session; modelled as part of first iteration)
+                await client.GetAsync("/api/config", context.ScenarioCancellationToken);
+
+                // Gallery listing
+                var pageResp = await client.GetAsync(
+                    "/api/photos?limit=30", context.ScenarioCancellationToken);
+                if (!pageResp.IsSuccessStatusCode)
+                    return Response.Fail(statusCode: ((int)pageResp.StatusCode).ToString());
+
+                var page = await pageResp.Content.ReadFromJsonAsync<PhotoPageDto>(
+                    JsonOptions, context.ScenarioCancellationToken);
+                if (page is null) return Response.Fail(statusCode: "parse_error");
+
+                // Fetch thumbnails with browser-like concurrency (6 parallel)
+                var pagePhotos = page.Photos.Take(30).ToList();
+                using var sem = new SemaphoreSlim(6, 6);
+                var thumbTasks = pagePhotos.Select(async p =>
+                {
+                    await sem.WaitAsync(context.ScenarioCancellationToken);
+                    try
+                    {
+                        var r = await client.GetAsync(
+                            $"/api/photos/{p.Id}/image?width=400",
+                            context.ScenarioCancellationToken);
+                        await r.Content.ReadAsByteArrayAsync(context.ScenarioCancellationToken);
+                        return r.IsSuccessStatusCode;
+                    }
+                    finally { sem.Release(); }
+                });
+                var thumbResults = await Task.WhenAll(thumbTasks);
+                if (thumbResults.Any(ok => !ok)) return Response.Fail(statusCode: "thumb_error");
+
+                // Think time: user browses the gallery page
+                await Task.Delay(
+                    TimeSpan.FromSeconds(4 + context.Random.NextDouble() * 4),
+                    context.ScenarioCancellationToken);
+
+                // 50% chance: scroll to the second page
+                if (page.NextCursor is not null && context.Random.NextDouble() < 0.5)
+                {
+                    var page2Resp = await client.GetAsync(
+                        $"/api/photos?limit=30&cursor={Uri.EscapeDataString(page.NextCursor)}",
+                        context.ScenarioCancellationToken);
+                    if (page2Resp.IsSuccessStatusCode)
+                    {
+                        var page2 = await page2Resp.Content.ReadFromJsonAsync<PhotoPageDto>(
+                            JsonOptions, context.ScenarioCancellationToken);
+                        if (page2?.Photos is { Count: > 0 } p2Photos)
+                        {
+                            using var sem2 = new SemaphoreSlim(6, 6);
+                            var page2Tasks = p2Photos.Take(30).Select(async p =>
+                            {
+                                await sem2.WaitAsync(context.ScenarioCancellationToken);
+                                try
+                                {
+                                    var r = await client.GetAsync(
+                                        $"/api/photos/{p.Id}/image?width=400",
+                                        context.ScenarioCancellationToken);
+                                    await r.Content.ReadAsByteArrayAsync(context.ScenarioCancellationToken);
+                                }
+                                finally { sem2.Release(); }
+                            });
+                            await Task.WhenAll(page2Tasks);
+                        }
+                    }
+                }
+
+                return Response.Ok();
+            }
+            catch (OperationCanceledException)
+            {
+                return Response.Ok(); // normal shutdown
+            }
+        });
+
+        return Scenario.WithLoadSimulations(scenario, [
+            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(30)),
+            Simulation.RampingConstant(vus, TimeSpan.FromMinutes(2)),
+            Simulation.KeepConstant(vus, TimeSpan.FromMinutes(holdMinutes))
+        ]);
+    }
+
+    // Models a guest viewing a specific photo — most expensive single request path because
+    // PhotoDetailPage.tsx fetches GET /api/photos (the full unpaginated list) for prev/next nav.
+    private static ScenarioProps BuildDetailViewScenario(
+        HttpClient client, IReadOnlyList<Photo> photos, int vus, int holdMinutes)
+    {
+        var scenario = Scenario.Create("detail_view", async context =>
+        {
+            try
+            {
+                var photo = photos[context.Random.Next(photos.Count)];
+
+                // Resolve code → PhotoDto
+                var codeResp = await client.GetAsync(
+                    $"/api/photos/{photo.Code}", context.ScenarioCancellationToken);
+                if (!codeResp.IsSuccessStatusCode)
+                    return Response.Fail(statusCode: ((int)codeResp.StatusCode).ToString());
+
+                // Full list for prev/next nav — intentionally exercised as it's expensive at scale
+                var listResp = await client.GetAsync("/api/photos", context.ScenarioCancellationToken);
+                if (!listResp.IsSuccessStatusCode)
+                    return Response.Fail(statusCode: ((int)listResp.StatusCode).ToString());
+                await listResp.Content.ReadAsByteArrayAsync(context.ScenarioCancellationToken);
+
+                // Display-size image
+                var imgResp = await client.GetAsync(
+                    $"/api/photos/{photo.Id}/image?width=1200", context.ScenarioCancellationToken);
+                if (!imgResp.IsSuccessStatusCode)
+                    return Response.Fail(statusCode: ((int)imgResp.StatusCode).ToString());
+                await imgResp.Content.ReadAsByteArrayAsync(context.ScenarioCancellationToken);
+
+                await Task.Delay(
+                    TimeSpan.FromSeconds(6 + context.Random.NextDouble() * 6),
+                    context.ScenarioCancellationToken);
+
+                return Response.Ok();
+            }
+            catch (OperationCanceledException)
+            {
+                return Response.Ok();
+            }
+        });
+
+        return Scenario.WithLoadSimulations(scenario, [
+            Simulation.KeepConstant(Math.Min(5, vus), TimeSpan.FromSeconds(30)),
+            Simulation.RampingConstant(vus, TimeSpan.FromMinutes(2)),
+            Simulation.KeepConstant(vus, TimeSpan.FromMinutes(holdMinutes))
+        ]);
+    }
+
+    // Models a guest downloading the full-resolution original.
+    private static ScenarioProps BuildDownloadScenario(
+        HttpClient client, IReadOnlyList<Photo> photos, int vus, int holdMinutes)
+    {
+        var scenario = Scenario.Create("download", async context =>
+        {
+            try
+            {
+                var photo = photos[context.Random.Next(photos.Count)];
+
+                var resp = await client.GetAsync(
+                    $"/api/photos/{photo.Id}/image", context.ScenarioCancellationToken);
+                if (!resp.IsSuccessStatusCode)
+                    return Response.Fail(statusCode: ((int)resp.StatusCode).ToString());
+
+                var bytes = await resp.Content.ReadAsByteArrayAsync(context.ScenarioCancellationToken);
+
+                await Task.Delay(
+                    TimeSpan.FromSeconds(20 + context.Random.NextDouble() * 20),
+                    context.ScenarioCancellationToken);
+
+                return Response.Ok(sizeBytes: bytes.LongLength);
+            }
+            catch (OperationCanceledException)
+            {
+                return Response.Ok();
+            }
+        });
+
+        return Scenario.WithLoadSimulations(scenario, [
+            Simulation.KeepConstant(Math.Min(2, vus), TimeSpan.FromSeconds(30)),
+            Simulation.RampingConstant(vus, TimeSpan.FromMinutes(2)),
+            Simulation.KeepConstant(vus, TimeSpan.FromMinutes(holdMinutes))
+        ]);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static HttpClient CreateHttpClient()
+    {
+        var handler = new LatencyHandler(TimeSpan.FromMilliseconds(100))
+        {
+            InnerHandler = _factory.Server.CreateHandler()
+        };
+        return new HttpClient(handler) { BaseAddress = _factory.Server.BaseAddress };
+    }
+
+    private static void PrintSummary(
+        NodeStats stats, int targetVUs, int holdMinutes, int photoCount, string reportFolder)
+    {
+        Console.WriteLine();
+        Console.WriteLine("════════════════════════════════════════════════════════");
+        Console.WriteLine(" PHOTO BOOTH GUEST LOAD TEST — SUMMARY");
+        Console.WriteLine("════════════════════════════════════════════════════════");
+        Console.WriteLine($" Config : {targetVUs} VUs | {photoCount} photos | {holdMinutes} min hold");
+        Console.WriteLine($" Total  : {stats.AllRequestCount:N0} requests | {stats.AllFailCount:N0} failures");
+        Console.WriteLine();
+
+        foreach (var s in stats.ScenarioStats)
+        {
+            var ok   = s.Ok;
+            var fail = s.Fail;
+            Console.WriteLine($" [{s.ScenarioName}]");
+            Console.WriteLine($"   OK    {ok.Request.Count,8:N0} req  |  {ok.Request.RPS,7:F1} RPS");
+            Console.WriteLine($"   Fail  {fail.Request.Count,8:N0} req");
+            Console.WriteLine($"   Latency  p50={ok.Latency.Percent50:F0}ms  " +
+                              $"p95={ok.Latency.Percent95:F0}ms  " +
+                              $"p99={ok.Latency.Percent99:F0}ms  " +
+                              $"(includes 100ms simulated RTT)");
+            Console.WriteLine();
+        }
+
+        Console.WriteLine(" ── Analytic bandwidth ceiling ──────────────────────");
+        Console.WriteLine("   Client 10 Mbps:");
+        Console.WriteLine($"     Full-res ~2MB photo   → {2.0 * 8 / 10.0:F1}s minimum download");
+        Console.WriteLine($"     Gallery page (30×50KB)→ {30 * 50.0 * 8 / (10.0 * 1024):F1}s minimum thumbnail load");
+        Console.WriteLine("   Server 200 Mbps:");
+        Console.WriteLine($"     Max concurrent full-res downloads → {200 / (2.0 * 8):F0}");
+        Console.WriteLine();
+        Console.WriteLine(" ── How to find the limit ────────────────────────────");
+        Console.WriteLine("   Increase LOADTEST_TARGET_USERS until p95 of gallery_browse");
+        Console.WriteLine("   (minus 100ms baseline) exceeds ~2s, or error rate > 1%.");
+        Console.WriteLine("   That VU count is the answer to 'how many concurrent guests'.");
+        Console.WriteLine();
+        Console.WriteLine($" Report → {reportFolder}");
+        Console.WriteLine("════════════════════════════════════════════════════════");
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
+++ b/tests/PhotoBooth.Server.Tests/GuestLoadTests.cs
@@ -4,11 +4,16 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using NBomber.Contracts;
 using NBomber.Contracts.Stats;
 using NBomber.CSharp;
 using PhotoBooth.Application.DTOs;
+using PhotoBooth.Application.Services;
 using PhotoBooth.Domain.Entities;
+using PhotoBooth.Domain.Interfaces;
+using PhotoBooth.Infrastructure.Imaging;
+using PhotoBooth.Infrastructure.Storage;
 using PhotoBooth.Server.Tests.LoadTesting;
 
 namespace PhotoBooth.Server.Tests;
@@ -59,16 +64,33 @@ public sealed class GuestLoadTests
                 {
                     config.AddInMemoryCollection(new Dictionary<string, string?>
                     {
+                        // Camera and trigger overrides are read at DI-registration time so
+                        // ConfigureAppConfiguration is early enough for these.
                         ["Camera:Provider"] = "mock",
-                        ["PhotoStorage:Path"] = _seeded.BasePath,
-                        ["Event:Name"] = _seeded.EventName,
                         ["Trigger:RestrictToLocalhost"] = "false",
-                        // Prevent watchdog from shutting down the host mid-test
                         ["Watchdog:ServerInactivityMinutes"] = "0"
                     });
                 });
                 builder.ConfigureServices(services =>
                 {
+                    // PhotoStorage:Path is captured as a local variable early in Program.cs
+                    // before ConfigureAppConfiguration overrides apply, so the repository and
+                    // resizer must be replaced here where the seeded paths are used directly.
+                    RemoveService<IPhotoRepository>(services);
+                    services.AddSingleton<IPhotoRepository>(sp =>
+                        new FileSystemPhotoRepository(
+                            _seeded.BasePath,
+                            _seeded.EventName,
+                            sp.GetRequiredService<ILogger<FileSystemPhotoRepository>>()));
+
+                    RemoveService<IImageResizer>(services);
+                    services.AddSingleton<IImageResizer>(sp =>
+                        new OpenCvImageResizer(
+                            sp.GetRequiredService<IPhotoRepository>(),
+                            Path.Combine(_seeded.BasePath, ".thumbnails"),
+                            jpegQuality: 80,
+                            sp.GetRequiredService<ILogger<OpenCvImageResizer>>()));
+
                     // Photos are pre-warmed by PhotoSeeder; disable background warmup
                     // so it doesn't compete with load-test requests at startup.
                     var warmup = services.FirstOrDefault(d =>
@@ -323,6 +345,12 @@ public sealed class GuestLoadTests
             InnerHandler = _factory.Server.CreateHandler()
         };
         return new HttpClient(handler) { BaseAddress = _factory.Server.BaseAddress };
+    }
+
+    private static void RemoveService<T>(IServiceCollection services)
+    {
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(T));
+        if (descriptor != null) services.Remove(descriptor);
     }
 
     private static void PrintSummary(

--- a/tests/PhotoBooth.Server.Tests/LoadTesting/LatencyHandler.cs
+++ b/tests/PhotoBooth.Server.Tests/LoadTesting/LatencyHandler.cs
@@ -1,0 +1,14 @@
+namespace PhotoBooth.Server.Tests.LoadTesting;
+
+// Adds a simulated round-trip delay to every HTTP request to approximate real network conditions.
+internal sealed class LatencyHandler(TimeSpan latency) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await Task.Delay(latency / 2, cancellationToken);
+        var response = await base.SendAsync(request, cancellationToken);
+        await Task.Delay(latency / 2, cancellationToken);
+        return response;
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/LoadTesting/PhotoSeeder.cs
+++ b/tests/PhotoBooth.Server.Tests/LoadTesting/PhotoSeeder.cs
@@ -1,0 +1,110 @@
+using System.Runtime.InteropServices;
+using OpenCvSharp;
+using PhotoBooth.Domain.Entities;
+
+namespace PhotoBooth.Server.Tests.LoadTesting;
+
+internal sealed record SeededPhotos(string BasePath, string EventName, IReadOnlyList<Photo> Photos)
+{
+    public void Cleanup()
+    {
+        if (Directory.Exists(BasePath))
+            Directory.Delete(BasePath, recursive: true);
+    }
+}
+
+internal static class PhotoSeeder
+{
+    // Mirrors IImageResizer.AllowedWidths
+    private static readonly int[] AllowedWidths = [200, 400, 800, 1200, 1920];
+
+    public static SeededPhotos Seed(int photoCount)
+    {
+        var basePath = Path.Combine(Path.GetTempPath(), $"photobooth-loadtest-{Guid.NewGuid():N}");
+        const string eventName = "load-test";
+        var eventDir = Path.Combine(basePath, eventName);
+        var thumbnailDir = Path.Combine(basePath, ".thumbnails");
+        Directory.CreateDirectory(eventDir);
+        Directory.CreateDirectory(thumbnailDir);
+
+        var photos = new List<Photo>(photoCount);
+        var baseTime = DateTime.UtcNow.AddDays(-1);
+
+        for (var i = 0; i < photoCount; i++)
+        {
+            var id = Guid.NewGuid();
+            var code = (i + 1).ToString();
+            var paddedCode = code.PadLeft(5, '0');
+            var filePath = Path.Combine(eventDir, $"{paddedCode}-{id}.jpg");
+
+            var jpeg = GenerateJpeg(seed: i);
+            File.WriteAllBytes(filePath, jpeg);
+
+            // Pre-warm the thumbnail cache matching OpenCvImageResizer's naming convention
+            // so ThumbnailWarmupService (if still registered) finds nothing to do.
+            PreGenerateThumbnails(jpeg, id, thumbnailDir);
+
+            photos.Add(new Photo
+            {
+                Id = id,
+                Code = code,
+                FilePath = filePath,
+                CapturedAt = baseTime.AddSeconds(i * 60)
+            });
+        }
+
+        return new SeededPhotos(basePath, eventName, photos);
+    }
+
+    private static void PreGenerateThumbnails(byte[] originalJpeg, Guid photoId, string thumbnailDir)
+    {
+        using var src = Mat.FromImageData(originalJpeg, ImreadModes.Color);
+
+        foreach (var targetWidth in AllowedWidths)
+        {
+            var cachePath = Path.Combine(thumbnailDir, $"{photoId}_{targetWidth}.jpg");
+
+            if (src.Width <= targetWidth)
+            {
+                // OpenCvImageResizer returns original bytes without resizing and caches them
+                File.WriteAllBytes(cachePath, originalJpeg);
+                continue;
+            }
+
+            var scale = (double)targetWidth / src.Width;
+            using var dst = new Mat();
+            Cv2.Resize(src, dst, new Size(targetWidth, (int)(src.Height * scale)),
+                interpolation: InterpolationFlags.Area);
+            Cv2.ImEncode(".jpg", dst, out var thumbData,
+                new ImageEncodingParam(ImwriteFlags.JpegQuality, 80));
+            File.WriteAllBytes(cachePath, thumbData);
+        }
+    }
+
+    // Generates a 1920×1080 JPEG with a colored gradient + hash-derived variation per seed.
+    // The slight per-pixel variation prevents trivial JPEG compression so files have realistic
+    // sizes (~80–200 KB) without requiring actual camera photos.
+    private static byte[] GenerateJpeg(int seed)
+    {
+        const int Width = 1920;
+        const int Height = 1080;
+
+        var pixelData = new byte[Height * Width * 3];
+        for (var i = 0; i < pixelData.Length; i += 3)
+        {
+            var pixel = i / 3;
+            var row = pixel / Width;
+            var col = pixel % Width;
+            var h = (pixel * 1664525 + seed * 22695477) & 0xFFFFFF;
+            pixelData[i]     = (byte)((col * 200 / Width     + (seed * 17 % 56) + (h & 0x1F))         & 0xFF);
+            pixelData[i + 1] = (byte)((row * 200 / Height    + (seed * 31 % 56) + ((h >> 8) & 0x1F))  & 0xFF);
+            pixelData[i + 2] = (byte)(((col + row) * 100 / (Width + Height) + (seed * 53 % 56) + ((h >> 16) & 0x1F)) & 0xFF);
+        }
+
+        using var mat = new Mat(Height, Width, MatType.CV_8UC3);
+        Marshal.Copy(pixelData, 0, mat.Data, pixelData.Length);
+
+        Cv2.ImEncode(".jpg", mat, out var jpegData, new ImageEncodingParam(ImwriteFlags.JpegQuality, 85));
+        return jpegData;
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/PhotoBooth.Server.Tests.csproj
+++ b/tests/PhotoBooth.Server.Tests/PhotoBooth.Server.Tests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="MSTest" />
+    <PackageReference Include="NBomber" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds an exploratory load test (issue #223) to characterise how many concurrent guests the server can serve before latency or errors become unacceptable.

## What this adds

- **** — NBomber 6.x integration test with three scenarios mirroring real guest behaviour:
  -  (60% of VUs): fetches paginated photo list + 30 thumbnails at width=400, 6 in parallel
  -  (30%): code lookup + full unpaginated list (for prev/next nav) + display image at width=1200
  -  (10%): full-resolution original

- **** — generates synthetic 1920x1080 JPEGs using OpenCvSharp and pre-warms all thumbnail cache sizes before the test starts

- **** — injects 100ms simulated RTT (50ms each way) on every request

## Key design decisions

- Uses WebApplicationFactory TestServer (not real Kestrel) — all server-side code runs, Kestrel connection queuing is not under load
- FileSystemPhotoRepository and OpenCvImageResizer are used directly so disk I/O and resize paths are exercised
- Bandwidth is not simulated in-process; analytic ceilings are printed in the summary
- Marked [TestCategory(Integration)] — excluded from CI

## How to run

dotnet test tests/PhotoBooth.Server.Tests --filter FullyQualifiedName~GuestLoadTests --logger console;verbosity=detailed

Default run takes ~2 minutes. Use LOADTEST_TARGET_USERS, LOADTEST_PHOTO_COUNT and LOADTEST_DURATION_MIN to scale up.

## Finding the concurrent-user limit

Increase LOADTEST_TARGET_USERS until gallery_browse p95 (minus 100ms baseline) exceeds ~2s or error rate exceeds 1%. The last clean value is the answer.

Closes #223