### PR TITLE
feat: add codebase-health-check skill

### DIFF
--- a/.claude/skills/codebase-health-check/SKILL.md
+++ b/.claude/skills/codebase-health-check/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: codebase-health-check
+description: This skill should be used when the user asks to "run a codebase health check", "do a maintenance review", "audit the codebase", "review code health", "check for tech debt", "review dependencies", or wants a periodic whole-codebase health assessment that files findings as labeled GitHub issues. Also trigger when the user mentions running this "every few months" or asks what should be improved across the codebase.
+version: 0.1.0
+---
+
+# Codebase Health Check
+
+A periodic (every-few-months) whole-codebase health assessment for the photo-booth-take-two repository. Examines nine dimensions, triages findings by priority and area, and files each as a labeled GitHub issue after user approval.
+
+This skill is **read-only until the confirmation gate** at Phase 3. No code is modified; no issues are filed without approval.
+
+Load `references/dimension-checklist.md` now for the detailed per-dimension questions before beginning Phase 0.
+
+---
+
+## Workflow
+
+### Phase 0 — Orient
+
+1. Read `CLAUDE.md`, `SPEC.md`, `README.md` to understand the intended architecture and user-facing behavior.
+2. Search for prior health-check runs by querying GitHub: `gh issue list --state all --search "codebase health check" --limit 10`. Note the date of the most recent tracking issue; focus subsequent analysis on what could have changed since then.
+3. Record the current date (available from `date` in Bash). It will appear in the tracking issue title.
+
+### Phase 1 — Assess
+
+Spawn parallel subagents (using the `Agent` tool with `subagent_type: "Explore"` or `"general-purpose"`) to cover the nine dimensions concurrently. Assign each agent a specific dimension and its checklist from `references/dimension-checklist.md`. Collate results before proceeding.
+
+**Dimensions to assess** (see `references/dimension-checklist.md` for detailed questions):
+
+1. **Architecture & code organization** — layer-boundary integrity, clean-arch dependency direction, dead code, naming consistency.
+2. **Documentation accuracy & drift** — cross-check `CLAUDE.md`/`SPEC.md`/`README.md` claims against actual code, config, and commands.
+3. **Security** — evaluate the controls described in `CLAUDE.md §Security` against the current implementation; check input validation, secret handling.
+4. **Dependencies** — necessity, license acceptability, maintenance status, CVEs, and "would we still choose this today". **Use `WebSearch` and `WebFetch`** for CVE lookups, license checks, npm/NuGet package status, and GitHub activity.
+5. **Test coverage & usefulness** — per-layer gaps, `[TestCategory("Integration")]` classification correctness, assertion-quality conventions.
+6. **Observability & logging** — Serilog usage, log levels, diagnosability of the unattended booth at runtime.
+7. **CI/CD & build hygiene** — workflow file health, compiler strictness, reproducibility, missing tooling config.
+8. **Performance & resilience** — error handling, resilience patterns, hotspots beyond the existing load test.
+9. **Accessibility & i18n** — frontend a11y, EN/ES i18n coverage, guest-gallery UX correctness.
+
+For the **security** and **dependencies** dimensions, always fetch current information from the internet:
+- Search for CVEs on known packages (OpenCvSharp4, Serilog, NBomber, MessagePack, React, Vite, react-router-dom, react-qr-code, react-zoom-pan-pinch).
+- Verify licenses are OSI-approved and compatible with this project (MIT/Apache-2/BSD preferred).
+- Check GitHub repository activity (last commit, open issues, stars) to assess maintenance health.
+
+### Phase 2 — Triage & Group
+
+For each raw finding from Phase 1:
+
+1. Discard findings that are not actionable (observations, style opinions without impact, things already tracked in open issues).
+2. Assign **exactly one** `priority` label and **at least one** `area` label from the taxonomy below.
+3. Write a one-line rationale summarizing impact and evidence.
+4. Deduplicate: if two findings cover the same root cause, merge them.
+5. **Group related findings** into potential PRs. Two or more issues belong in the same group when they: touch the same file or subsystem, would be fixed by the same type of change (e.g. "upgrade all frontend deps"), or are conceptually related enough that one PR fixing them is lower-risk than separate PRs. Name each group with a short action phrase (e.g. "Frontend dependency upgrades", "Improve camera error recovery", "Documentation cleanup"). Groups are displayed in the tracking issue so an agent can be instructed to fix an entire group in one PR.
+
+A finding can belong to only one group. Findings with no natural sibling form a "Standalone" group.
+
+**Priority labels:**
+| Label | Color | Meaning |
+|---|---|---|
+| `priority:high` | `#b60205` | Security risk, data loss, or blocks normal operation |
+| `priority:medium` | `#fbca04` | Degrades quality, causes confusion, or accumulates debt |
+| `priority:low` | `#0e8a16` | Nice-to-have improvement, low risk if deferred |
+
+**Area labels:**
+| Label | Color | Meaning |
+|---|---|---|
+| `area:frontend` | `#0075ca` | React/TypeScript/Vite source in `src/PhotoBooth.Web/` |
+| `area:backend` | `#1d76db` | .NET C# projects under `src/` |
+| `area:tests` | `#e4e669` | Test projects under `tests/` |
+| `area:documentation` | `#cfd3d7` | Markdown docs (CLAUDE.md, SPEC.md, README.md) |
+| `area:security` | `#d73a4a` | Security controls, headers, rate limiting, CVEs |
+| `area:dependencies` | `#0366d6` | NuGet or npm package choices |
+| `area:ci-build` | `#5319e7` | GitHub Actions, build config, tooling files |
+
+### Phase 3 — Present & Confirm
+
+Present findings organized by group, then stop for approval. Use this format:
+
+```
+**Group: Frontend dependency upgrades** (1 PR)
+| # | Title | Area(s) | Priority | Rationale |
+|---|-------|---------|----------|-----------|
+| 1 | Upgrade react-qr-code to v3 | dependencies, frontend | medium | Last release 18 mo ago; v3 drops legacy deps |
+| 2 | Upgrade react-zoom-pan-pinch to v5 | dependencies, frontend | low | Maintenance patch; no CVEs |
+
+**Group: Improve camera error recovery** (1 PR)
+| # | Title | Area(s) | Priority | Rationale |
+|---|-------|---------|----------|-----------|
+| 3 | Handle OpenCV camera disconnect gracefully | backend | high | USB unplug leaves booth in broken state |
+| 4 | Add ADB reconnection retry logic | backend | medium | Connection drop requires full restart |
+
+**Standalone**
+| # | Title | Area(s) | Priority | Rationale |
+|---|-------|---------|----------|-----------|
+| 5 | Replace Vite boilerplate README in src/PhotoBooth.Web | documentation | low | Default template README confuses contributors |
+```
+
+Then **stop and ask the user for approval** using `AskUserQuestion` with options: "File all issues", "Let me edit the list first", "Cancel". Do not proceed to Phase 4 until the user approves.
+
+If the user asks to edit: accept their changes (remove rows, change priorities, regroup, rewrite titles) and confirm once more before proceeding.
+
+### Phase 4 — Ensure Labels Exist
+
+Before creating issues, idempotently ensure all needed labels exist:
+
+```bash
+gh label list --limit 100
+```
+
+For each `priority:*` and `area:*` label that is missing, create it:
+
+```bash
+gh label create "priority:high" --color "b60205" --description "Security risk, data loss, or blocks normal operation"
+gh label create "area:backend" --color "1d76db" --description ".NET C# projects under src/"
+```
+
+Use a separate `gh label create` call per label. If a label already exists, the command will error — catch this with `|| true` or by checking the list first.
+
+### Phase 5 — File Issues
+
+For each approved finding, create one GitHub issue:
+
+**Issue body format:**
+```
+## Finding
+
+<one-paragraph description of the problem, with file:line references where possible>
+
+## Why it matters
+
+<impact on the codebase, users, or development velocity>
+
+## Suggested fix
+
+<concrete suggestion — library upgrade, code change, doc update, etc.>
+
+## Effort estimate
+
+<S / M / L>
+
+---
+_Part of health check tracking issue #<tracking-issue-number>_
+```
+
+**Issue creation command** (follow CLAUDE.md conventions — plain strings, no heredocs, no backticks):
+```bash
+gh issue create --title "<title>" --body "<body>" --label "priority:high" --label "area:security"
+```
+
+After all child issues are created, create the **tracking issue**:
+- Title: `Codebase health check — <YYYY-MM-DD>`
+- Body: findings organized by group (same grouping as Phase 3), with each group presented as a section. Format:
+
+```
+## Group: Frontend dependency upgrades
+
+Fix together in one PR — all touch frontend deps in `src/PhotoBooth.Web/package.json`.
+
+- [ ] #42 Upgrade react-qr-code to v3
+- [ ] #43 Upgrade react-zoom-pan-pinch to v5
+
+## Group: Improve camera error recovery
+
+Fix together in one PR — all touch camera provider implementations under `src/PhotoBooth.Infrastructure/Camera/`.
+
+- [ ] #44 Handle OpenCV camera disconnect gracefully
+- [ ] #45 Add ADB reconnection retry logic
+
+## Standalone
+
+- [ ] #46 Replace Vite boilerplate README in src/PhotoBooth.Web
+
+---
+## Summary
+| Priority | Count |
+|----------|-------|
+| High     | 1     |
+| Medium   | 3     |
+| Low      | 1     |
+
+Dimensions with no findings: Architecture & code organization, Observability & logging
+```
+
+- Labels: none required (it's a meta issue).
+
+Then comment on each child issue referencing the tracking issue number (optional if the body already includes it).
+
+### Phase 6 — Report
+
+Output a brief summary:
+- Tracking issue URL
+- Count of issues filed (by priority)
+- Any dimensions where no findings were raised (explicitly, so the user knows the clean areas)
+- Suggested cadence for the next run (default: 3 months)
+
+---
+
+## Conventions to honor
+
+- Follow CLAUDE.md strictly: GitHub Flow, plain-string `gh` args, no heredocs, no `$()` substitution, no backticks in strings.
+- This skill only **files issues** — it does not create branches, edit source files, or open PRs.
+- For dependency CVE checks, search by package name + current year (e.g. "OpenCvSharp4 CVE 2026", "Serilog vulnerability 2026") and fetch the NuGet/npm page to verify the latest version.
+- When in doubt about priority, prefer `medium` over `high` — reserve `high` for concrete security or correctness risks with evidence.

--- a/.claude/skills/codebase-health-check/SKILL.md
+++ b/.claude/skills/codebase-health-check/SKILL.md
@@ -39,7 +39,8 @@ Spawn parallel subagents (using the `Agent` tool with `subagent_type: "Explore"`
 9. **Accessibility & i18n** — frontend a11y, EN/ES i18n coverage, guest-gallery UX correctness.
 
 For the **security** and **dependencies** dimensions, always fetch current information from the internet:
-- Search for CVEs on known packages (OpenCvSharp4, Serilog, NBomber, MessagePack, React, Vite, react-router-dom, react-qr-code, react-zoom-pan-pinch).
+- Discover current backend packages from `Directory.Packages.props` and current frontend packages from `src/PhotoBooth.Web/package.json` before searching — do not rely on a hardcoded list.
+- Search for CVEs on each discovered package.
 - Verify licenses are OSI-approved and compatible with this project (MIT/Apache-2/BSD preferred).
 - Check GitHub repository activity (last commit, open issues, stars) to assess maintenance health.
 

--- a/.claude/skills/codebase-health-check/references/dimension-checklist.md
+++ b/.claude/skills/codebase-health-check/references/dimension-checklist.md
@@ -1,0 +1,199 @@
+# Dimension Checklist — Codebase Health Check
+
+Detailed review questions for each of the nine dimensions. Read this file at the start of Phase 1 to guide assessment. Each section maps to one subagent assignment.
+
+---
+
+## 1. Architecture & Code Organization
+
+**Goal:** verify the clean-architecture layering is intact and the codebase stays coherent as it grows.
+
+- [ ] **Dependency direction**: Domain has zero outward references. Application references only Domain. Infrastructure references Domain and Application. Server references all layers. Verify with `dotnet build` output or by scanning csproj `<ProjectReference>` entries.
+- [ ] **Namespace / folder alignment**: each project's namespaces match its folder structure. No `.Domain` types used directly in `.Server` without going through `.Application`.
+- [ ] **Dead code**: any unused classes, methods, or interfaces? Check with IDE warnings or search for types that are defined but never referenced.
+- [ ] **Consistency**: naming conventions consistent (service suffix, repository suffix, provider suffix, etc.)? Any class doing too much (SRP violation)?
+- [ ] **Solution file**: still using `.slnx` format (not `.sln`). Check `PhotoBooth.slnx` at repo root.
+- [ ] **New layers or projects added** since the last health check? If so, do they fit the clean-arch model?
+- [ ] **Front-end component structure**: are React components organised logically in `src/PhotoBooth.Web/src/`? Any obvious colocation issues (logic in UI components, no custom hooks, etc.)?
+
+---
+
+## 2. Documentation Accuracy & Drift
+
+**Goal:** detect claims in docs that no longer match the code, config, or commands.
+
+- [ ] **CLAUDE.md §Architecture**: verify the layer names, key interfaces (`ICameraProvider`, `IInputProvider`, `IPhotoRepository`, `IPhotoCodeGenerator`), key services (`PhotoCaptureService`, `CaptureWorkflowService`), and key events (`IEventBroadcaster`) still exist with those exact names.
+- [ ] **CLAUDE.md §Build Commands**: run each listed command mentally — are the paths and flags still correct? E.g. `dotnet run --project src/PhotoBooth.Server`, `pnpm run build` in `src/PhotoBooth.Web`.
+- [ ] **CLAUDE.md §Tech Stack**: still .NET 10, React + TypeScript + Vite, pnpm? Check `global.json` (if it now exists), `package.json`, and target framework in `Directory.Build.props`.
+- [ ] **CLAUDE.md §Security**: does `SecurityHeadersMiddleware` still exist? Is the rate-limiting config still at `/api/photos/capture` and `/api/photos/trigger`? Still defaults 5 req / 10 s?
+- [ ] **CLAUDE.md §Dependency Policy**: does Polly appear? (It should not — it is listed as an example of acceptable deps but was never added.) Any packages that violate the policy?
+- [ ] **CLAUDE.md §Test Classification**: re-check the listed CI filter `--filter "TestCategory!=Integration"` against the actual CI workflow file.
+- [ ] **README.md**: does it accurately describe current features (slideshow/Ken Burns, keyboard nav, download code/QR, webcam + Android-ADB cameras, EN/ES i18n)? Are installation steps still correct?
+- [ ] **SPEC.md**: any functional behaviors described that the code contradicts?
+- [ ] **`src/PhotoBooth.Web/README.md`**: still the unmodified Vite+React boilerplate? If so, it should either be removed or replaced with project-specific content.
+- [ ] **Installer docs**: `CLAUDE.md §Installer` build command — is the path and flag syntax still valid?
+
+---
+
+## 3. Security
+
+**Goal:** evaluate the actual implementation against the stated controls and catch any gaps.
+
+- [ ] **SecurityHeadersMiddleware**: confirm CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers are set. Are the CSP directives appropriately restrictive for a local-network React app?
+- [ ] **Rate limiting**: confirm middleware is registered and applied only to `/api/photos/capture` and `/api/photos/trigger`. Default config still 5 / 10 s?
+- [ ] **Localhost gating**: `BoothLocalhostMiddleware` — confirm it blocks non-localhost requests on any endpoint that should be restricted.
+- [ ] **Input validation**: are file paths used in `IPhotoRepository` sanitised? Any risk of path traversal?
+- [ ] **Secrets**: are there any secrets, credentials, or API keys in config files, `appsettings.json`, or committed anywhere? (Check for `password`, `secret`, `key`, `token` patterns in `appsettings*.json` and `*.cs` files.)
+- [ ] **Dependency CVEs**: check NuGet and npm packages against current advisories (see Dimension 4 — security findings should also be tagged `area:security`).
+- [ ] **Download code brute-force**: `SequentialCodeGenerator` produces predictable numeric codes. Is there any rate-limiting or throttling on the download endpoint?
+- [ ] **HTTP vs HTTPS**: the README/CLAUDE says no HSTS (appropriate for local network). Confirm no accidental HTTPS downgrade scenarios.
+- [ ] **ADB / Android integration**: `AndroidCameraProvider` and `AdbService` — any security risk in the ADB command execution (command injection via device names or paths)?
+
+---
+
+## 4. Dependencies
+
+**Goal:** confirm every dependency is necessary, licensed acceptably, actively maintained, and still the best choice. **Use WebSearch and WebFetch throughout this dimension.**
+
+### Backend (NuGet)
+
+For each package, search "[package name] NuGet 2026" and "[package name] CVE 2026":
+
+| Package | Check |
+|---|---|
+| `OpenCvSharp4` + runtimes | Necessary? (used for webcam). License (Apache-2)? Latest version? Still the right wrapper for OpenCV on .NET? |
+| `Serilog.AspNetCore` | Version current? Known vulnerabilities? Any BREAKING changes in the major version? |
+| `Swashbuckle.AspNetCore` | Still maintained? (There was a period of uncertainty — verify.) Necessary for this app? Could `Microsoft.AspNetCore.OpenApi` replace it? |
+| `Microsoft.AspNetCore.OpenApi` | Both this AND Swashbuckle? Are both needed? |
+| `NBomber` | Only in test project — acceptable. License (MIT)? Version current? |
+| `MessagePack` | Security-pinned transitive dep. Still needed as a pin? |
+| `MSTest` | Version current? Any migration to newer test runner patterns warranted? |
+
+### Frontend (npm via pnpm)
+
+For each package, search "[package name] npm 2026" and "[package name] security advisory 2026":
+
+| Package | Check |
+|---|---|
+| `react` / `react-dom` | 19.x — is this still the latest stable? Any security advisories? |
+| `react-router-dom` | v7 — latest patch? Any known issues? |
+| `react-qr-code` | Necessary? Actively maintained? Could a lighter alternative serve better? |
+| `react-zoom-pan-pinch` | Necessary? Actively maintained? Last commit date? |
+| `vite` | Latest v8? Any CVEs? |
+| `typescript` | `~6.0.0` — latest patch in v6? |
+| `vitest` | Latest v4? Compatible with current TS/Vite? |
+| `eslint` + plugins | All on compatible versions? No peer-dep conflicts? |
+
+### License acceptability checklist
+- MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause: ✅ acceptable.
+- GPL, LGPL: ⚠️ check viral clause; may require disclosure.
+- SSPL, BSL, Elastic License: ❌ not OSI-approved; flag.
+- Unlicense / CC0: ✅ public domain.
+
+---
+
+## 5. Test Coverage & Usefulness
+
+**Goal:** confirm tests are well-structured, cover important scenarios, and won't give false confidence.
+
+- [ ] **Per-layer coverage**:
+  - `PhotoBooth.Domain`: no test project (no logic to test — acceptable). Still true?
+  - `PhotoBooth.Application.Tests`: covers `PhotoCaptureService`, `CaptureWorkflowService`, `UrlPrefixGenerator`. Any new services added without tests?
+  - `PhotoBooth.Infrastructure.Tests`: covers file repo, HTTP handler, OpenCV, EventBroadcaster, code generator, input, camera (ADB/Android), imaging. Any new providers/services added without tests?
+  - `PhotoBooth.Server.Tests`: covers endpoints, middleware, rate limiting, fallback route, networking, watchdog, settings. Any new endpoints without tests?
+- [ ] **Frontend tests**: `src/PhotoBooth.Web/` — are Vitest tests present? Do they cover meaningful component behavior, not just rendering smoke tests?
+- [ ] **`[TestCategory("Integration")]` correctness**: re-read CLAUDE.md's classification rule (real external hardware, OS-level resource unavailable in CI, long-running). Spot-check the 12 classified test classes. Any mis-classified unit tests (they'd be skipped in CI unnecessarily)?
+- [ ] **Assertion quality**: CLAUDE.md §Coding Conventions lists MSTest analyzer rules (MSTEST0037). Scan for `Assert.AreEqual(expected, collection.Count)` instead of `Assert.HasCount`, `Assert.IsTrue(...Contains(...))` instead of `Assert.Contains`.
+- [ ] **Test doubles**: are the stubs/fakes under `TestDoubles/` still aligned with their interfaces? (If an interface signature changed and the stub wasn't updated, tests may pass against a stale contract.)
+- [ ] **Flaky tests**: any tests that depend on timing, file system state, or random data without deterministic seeding?
+- [ ] **NBomber load test**: `GuestLoadTests` — is the baseline latency comment still accurate? Are the three scenarios (gallery_browse 60%, detail_view 30%, download 10%) still representative?
+
+---
+
+## 6. Observability & Logging
+
+**Goal:** confirm the unattended booth is diagnosable when something goes wrong.
+
+- [ ] **Serilog configuration**: is `appsettings.json` Serilog section configured (log level, sinks)? Appropriate defaults for production (not `Debug` globally)?
+- [ ] **Log coverage**: are errors and warnings logged at the right level? Check exception handlers in `Program.cs` and service implementations.
+- [ ] **Structured logging**: are log messages using structured templates (`Log.Information("Captured {PhotoId}", id)`) rather than string interpolation?
+- [ ] **Sensitive data in logs**: any risk of logging PII, file paths that reveal user info, or download codes?
+- [ ] **Startup logging**: does the application log its configuration (camera provider, listen addresses) on startup so an unattended booth operator can confirm correct boot?
+- [ ] **Error surfacing to operator**: when a capture fails (camera unavailable, disk full, etc.), is the error surfaced clearly — in logs AND via the SSE event stream to the frontend?
+- [ ] **Log rotation/retention**: any config for log file size/retention so the booth doesn't fill disk over months of operation?
+
+---
+
+## 7. CI/CD & Build Hygiene
+
+**Goal:** confirm the build pipeline is healthy, strict, and reproducible.
+
+- [ ] **`ci.yml`**: does it still correctly run `dotnet test --filter "TestCategory!=Integration"`? Are both `dotnet` and `frontend` jobs present? Does the frontend job run `pnpm run lint` and `pnpm run test`?
+- [ ] **`release.yml`**: does the MSI/zip build still work? Does it correctly extract the version from the git tag?
+- [ ] **`TreatWarningsAsErrors true`** in `Directory.Build.props`: still present? This is a quality gate — confirm no warnings are being suppressed with pragmas or `<NoWarn>`.
+- [ ] **`global.json`** absent: pinning the .NET SDK version prevents "works on my machine" CI failures. Evaluate whether to add it (record the current SDK version from `dotnet --version`).
+- [ ] **`.editorconfig`** absent: code style is enforced via compiler rules but an `.editorconfig` would make formatting consistent across editors. Evaluate whether to add it.
+- [ ] **Central package management**: `Directory.Packages.props` — are all package versions defined there? Any package reference with an inline `Version="..."` in a csproj (which would bypass central management)?
+- [ ] **`CentralPackageTransitivePinningEnabled`**: still enabled? Any transitive pins that may now be unnecessary (the pinned version has been incorporated into a direct dependency)?
+- [ ] **`claude.yml`** workflow: still using a supported Claude Action version? Any deprecation warnings?
+- [ ] **Installer subtree**: `installer/Directory.Build.props` is an empty `<Project />` to reset root props — is this still necessary and correct?
+
+---
+
+## 8. Performance & Resilience
+
+**Goal:** confirm the booth handles hardware and network failures gracefully and doesn't degrade over long uptime.
+
+- [ ] **Error handling in `PhotoCaptureService` and `CaptureWorkflowService`**: are all `async` calls wrapped with appropriate try/catch? What happens if the camera fails mid-capture?
+- [ ] **OpenCV camera recovery**: if `OpenCvCameraProvider` loses the camera (USB unplug), does it recover on the next capture attempt or does it leave the system in a broken state?
+- [ ] **Android/ADB recovery**: if the ADB connection drops, does `AndroidCameraProvider` reconnect or fail permanently until restart?
+- [ ] **File system resilience**: if the photo storage directory fills up or becomes read-only, is this caught and surfaced gracefully?
+- [ ] **SSE event stream**: if a browser client disconnects and reconnects, does the event stream resume correctly? Any resource leak from abandoned SSE connections?
+- [ ] **`InactivityWatchdogService`**: what happens if the watchdog fires during an active capture? Is there a race condition?
+- [ ] **Memory/resource leaks**: `OpenCvCameraProvider` uses `Mat` objects — are they disposed correctly? Any `IDisposable` implementations that may leak?
+- [ ] **Long-running uptime**: any `static` state or in-memory collections that grow unboundedly (e.g. the photo gallery list — is it loaded from disk each request or cached in memory indefinitely)?
+- [ ] **Polly** (absent): are HTTP calls (e.g. from `BlockingHttpHandler`) retried on transient failure? If not, evaluate whether a retry policy is needed.
+
+---
+
+## 9. Accessibility & i18n
+
+**Goal:** confirm the guest-facing UI works for all guests.
+
+### Accessibility
+- [ ] **Image alt text**: do all `<img>` tags in the gallery and detail views have meaningful `alt` attributes (or `alt=""` for decorative images)?
+- [ ] **Keyboard navigation**: can guests navigate the gallery and detail view without a mouse? Are interactive elements (buttons, links) focusable and have visible focus styles?
+- [ ] **Colour contrast**: do text colours meet WCAG AA contrast ratios against their backgrounds? (Run a quick mental check on the design or note for manual testing.)
+- [ ] **ARIA roles**: are modals, dialogs, or interactive overlays correctly annotated?
+- [ ] **Zoom/pan (react-zoom-pan-pinch)**: is it accessible via keyboard or only via touch/mouse?
+- [ ] **Reduced motion**: does the Ken Burns slideshow respect `prefers-reduced-motion`?
+
+### Internationalisation
+- [ ] **i18n coverage**: the app supports EN and ES. Are all user-visible strings in both translation files? Any hard-coded English strings in components?
+- [ ] **Translation file locations**: where are translation files? Are they complete (no missing keys in either language)?
+- [ ] **Date/number formatting**: are any dates or counts formatted with locale-specific methods?
+- [ ] **RTL**: EN/ES are both LTR — no RTL concern currently. Note if a new language is added in future.
+
+---
+
+## Web Research Prompts (for Phase 1 dependency/security agents)
+
+Use these search queries during the assessment:
+
+```
+OpenCvSharp4 CVE security vulnerability 2026
+Serilog.AspNetCore security advisory 2026
+Swashbuckle.AspNetCore maintained 2026 Microsoft.AspNetCore.OpenApi
+NBomber 6 license 2026
+react 19 security advisory 2026
+react-router-dom 7 security 2026
+react-qr-code npm maintained 2026
+react-zoom-pan-pinch npm maintained 2026
+vite 8 CVE security 2026
+```
+
+For each package also visit its NuGet/npm page to check:
+- Last publish date
+- Weekly download trend (stability signal)
+- Listed vulnerabilities
+- Latest version vs pinned version in this repo

--- a/.claude/skills/codebase-health-check/references/dimension-checklist.md
+++ b/.claude/skills/codebase-health-check/references/dimension-checklist.md
@@ -55,34 +55,26 @@ Detailed review questions for each of the nine dimensions. Read this file at the
 
 **Goal:** confirm every dependency is necessary, licensed acceptably, actively maintained, and still the best choice. **Use WebSearch and WebFetch throughout this dimension.**
 
-### Backend (NuGet)
+Start by reading the current package lists from the repo — do not rely on any hardcoded list:
+- **Backend**: read `Directory.Packages.props` for all NuGet packages and versions.
+- **Frontend**: read `src/PhotoBooth.Web/package.json` for all `dependencies` and `devDependencies`.
 
-For each package, search "[package name] NuGet 2026" and "[package name] CVE 2026":
+### For each backend (NuGet) package, ask:
+- Is it still used? (Check for references in source — a package in `Directory.Packages.props` with no `<PackageReference>` in any csproj is a candidate for removal.)
+- Is it a transitive pin? If so, has the direct dependency caught up so the pin is no longer needed?
+- Is the pinned version current? Any newer version with bug fixes or security patches?
+- Any known CVEs? (Search "[package name] NuGet CVE [current year]".)
+- Is the license OSI-approved and compatible?
+- Is the package actively maintained? (Check NuGet page for last publish date and download trend.)
+- Is it still the right choice — or has a better-maintained or leaner alternative emerged?
 
-| Package | Check |
-|---|---|
-| `OpenCvSharp4` + runtimes | Necessary? (used for webcam). License (Apache-2)? Latest version? Still the right wrapper for OpenCV on .NET? |
-| `Serilog.AspNetCore` | Version current? Known vulnerabilities? Any BREAKING changes in the major version? |
-| `Swashbuckle.AspNetCore` | Still maintained? (There was a period of uncertainty — verify.) Necessary for this app? Could `Microsoft.AspNetCore.OpenApi` replace it? |
-| `Microsoft.AspNetCore.OpenApi` | Both this AND Swashbuckle? Are both needed? |
-| `NBomber` | Only in test project — acceptable. License (MIT)? Version current? |
-| `MessagePack` | Security-pinned transitive dep. Still needed as a pin? |
-| `MSTest` | Version current? Any migration to newer test runner patterns warranted? |
-
-### Frontend (npm via pnpm)
-
-For each package, search "[package name] npm 2026" and "[package name] security advisory 2026":
-
-| Package | Check |
-|---|---|
-| `react` / `react-dom` | 19.x — is this still the latest stable? Any security advisories? |
-| `react-router-dom` | v7 — latest patch? Any known issues? |
-| `react-qr-code` | Necessary? Actively maintained? Could a lighter alternative serve better? |
-| `react-zoom-pan-pinch` | Necessary? Actively maintained? Last commit date? |
-| `vite` | Latest v8? Any CVEs? |
-| `typescript` | `~6.0.0` — latest patch in v6? |
-| `vitest` | Latest v4? Compatible with current TS/Vite? |
-| `eslint` + plugins | All on compatible versions? No peer-dep conflicts? |
+### For each frontend (npm) package, ask:
+- Is it still used in the source?
+- Is the pinned version current? Any newer patch available?
+- Any known security advisories? (Search "[package name] npm security [current year]".)
+- Is the license acceptable?
+- Is the package actively maintained? (Check npm page for last publish date; check GitHub for last commit and open issues.)
+- For smaller niche packages: is it still the right choice, or could a lighter/more-maintained alternative serve better?
 
 ### License acceptability checklist
 - MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause: ✅ acceptable.
@@ -178,18 +170,12 @@ For each package, search "[package name] npm 2026" and "[package name] security 
 
 ## Web Research Prompts (for Phase 1 dependency/security agents)
 
-Use these search queries during the assessment:
+Before searching, read `Directory.Packages.props` for backend packages and `src/PhotoBooth.Web/package.json` for frontend packages to get the current list and pinned versions. Then for each package run a search of the form:
 
 ```
-OpenCvSharp4 CVE security vulnerability 2026
-Serilog.AspNetCore security advisory 2026
-Swashbuckle.AspNetCore maintained 2026 Microsoft.AspNetCore.OpenApi
-NBomber 6 license 2026
-react 19 security advisory 2026
-react-router-dom 7 security 2026
-react-qr-code npm maintained 2026
-react-zoom-pan-pinch npm maintained 2026
-vite 8 CVE security 2026
+<package-name> CVE security vulnerability <current-year>
+<package-name> npm maintained <current-year>         (for frontend packages)
+<package-name> NuGet maintained <current-year>       (for backend packages)
 ```
 
 For each package also visit its NuGet/npm page to check:


### PR DESCRIPTION
Adds a Claude Code skill for periodic whole-codebase health assessments (every few months). Invoke with /codebase-health-check or phrases like 'run a maintenance review' or 'audit the codebase'.

## What the skill does

- Assesses 9 dimensions in parallel: architecture, documentation drift, security, dependencies, test coverage, observability, CI/CD hygiene, performance/resilience, and a11y/i18n
- Uses WebSearch/WebFetch for live CVE and dependency maintenance checks
- Groups findings into named PR-sized clusters so related issues can be fixed together
- Presents a findings table for approval before touching GitHub
- Creates one labeled issue per finding (priority:high/medium/low + area:frontend/backend/tests/documentation/security/dependencies/ci-build) plus a tracking issue with the grouped checklist

## Files

- .claude/skills/codebase-health-check/SKILL.md - workflow and phases
- .claude/skills/codebase-health-check/references/dimension-checklist.md - detailed per-dimension review questions with repo-specific anchors