### PR TITLE
docs: add Architecture Decision Records (ADRs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,4 +198,5 @@ dotnet test tests/PhotoBooth.Server.Tests --filter "FullyQualifiedName~GuestLoad
 ## Reference
 
 - **SPEC.md**: Functional specification - describes how the application should work. Consult this for requirements and intended behavior.
+- **docs/adr/**: Architecture Decision Records — the *why* behind key architectural choices (layer split, SSE, pnpm, installer model, security model, code generation). Add a new ADR whenever making a consequential, non-obvious decision.
 - Previous implementation for Android integration patterns: https://github.com/magnusakselvoll/android-photo-booth-camera

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ installer/
   PhotoBooth.Installer/     # WiX MSI installer (per-user, no elevation)
 ```
 
+## Architecture Decision Records
+
+Key architectural choices are documented in [`docs/adr/`](docs/adr/). See the [ADR index](docs/adr/README.md) for the full list.
+
 ## Acknowledgments
 
 The Android camera integration is based on [android-photo-booth-camera](https://github.com/magnusakselvoll/android-photo-booth-camera).

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# NNNN. Title
+
+**Status:** Proposed / Accepted / Superseded by [NNNN](NNNN-title.md)
+
+**Date:** YYYY-MM-DD
+
+## Context
+
+What situation or problem prompted this decision? Include relevant constraints (technical, organisational, event-use-case-specific).
+
+## Decision
+
+What was decided? State it clearly and assertively.
+
+## Consequences
+
+What becomes easier or harder as a result? Include both positive consequences and trade-offs accepted.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Option A | … |
+| Option B | … |

--- a/docs/adr/0001-clean-architecture-layers.md
+++ b/docs/adr/0001-clean-architecture-layers.md
@@ -1,0 +1,34 @@
+# 0001. Clean architecture with four layers
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+PhotoBooth must support multiple camera backends (webcam via OpenCV, Android phone via ADB, mock for tests) and multiple storage backends, without the core business logic knowing which hardware is present. The application is also expected to be long-lived and actively tested, so testability matters.
+
+## Decision
+
+Structure the codebase as four distinct layers with a strict dependency rule (inner layers never depend on outer ones):
+
+- **Domain** (`PhotoBooth.Domain`): entities, interfaces, domain exceptions. No external dependencies.
+- **Application** (`PhotoBooth.Application`): services, DTOs, orchestration logic, event types. Depends only on Domain.
+- **Infrastructure** (`PhotoBooth.Infrastructure`): concrete implementations of Domain interfaces — camera providers, photo storage, code generation, SSE event broadcasting. Depends on Domain.
+- **Server** (`PhotoBooth.Server`): ASP.NET Core minimal API, middleware, endpoint mapping, static file serving. Depends on Application and Infrastructure.
+
+Key interfaces live in Domain (`ICameraProvider`, `IInputProvider`, `IPhotoRepository`, `IPhotoCodeGenerator`), allowing Infrastructure implementations to be swapped without touching business logic.
+
+## Consequences
+
+- Camera and storage backends can be swapped or extended by adding an Infrastructure implementation; Application is unaffected.
+- Unit tests can replace any Infrastructure component with a stub/fake without spinning up real hardware.
+- The dependency inversion means wiring happens at composition root (Server/`Program.cs`), which is the one place that knows about all layers.
+- Slightly more project files and ceremony compared to a single-project layout.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Single-project layout | All code in one project eliminates the structure enforced by project references, making accidental cross-layer coupling easy and invisible. |
+| Feature-folder layout (vertical slices) | Natural for CRUD apps, but PhotoBooth has a single primary workflow (capture → store → display); horizontal layering is a better fit and makes hardware-abstraction boundaries explicit. |

--- a/docs/adr/0002-sse-for-realtime-events.md
+++ b/docs/adr/0002-sse-for-realtime-events.md
@@ -1,0 +1,35 @@
+# 0002. Server-Sent Events for real-time event broadcasting
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+The booth operator page and the frontend need to receive real-time push notifications from the server: countdown ticks, capture-complete signals, and error events. The flow is purely server → client; clients never push events back over this channel.
+
+The project has a strict dependency-minimisation policy — external libraries are only added when genuinely needed. The target deployment is a local-network Windows machine with no external internet access.
+
+## Decision
+
+Use Server-Sent Events (SSE) over a plain HTTP endpoint for real-time push.
+
+`IEventBroadcaster` (in Application) exposes `BroadcastAsync` and `SubscribeAsync`. The Infrastructure implementation (`EventBroadcaster`) fans out events to registered `Channel<PhotoBoothEvent>` subscribers. The Server layer exposes a `/api/events` SSE endpoint that subscribes and streams `text/event-stream` responses.
+
+A periodic heartbeat (configurable via `Watchdog:SseHeartbeatIntervalSeconds`) keeps connections alive and lets the client-side watchdog detect stale connections.
+
+## Consequences
+
+- No external SignalR or WebSocket library required — SSE is built into `HttpResponse`.
+- Browser reconnection is automatic via the `EventSource` API; no reconnection logic needed on the server.
+- The abstraction (`IEventBroadcaster`) allows the Infrastructure implementation to be replaced (e.g., for testing with a stub) without changing Application or Server code.
+- SSE is unidirectional (server → client only). If bidirectional communication ever becomes necessary, this decision would need to be revisited.
+- Bounded channels (`Capacity = 100, FullMode = DropOldest`) protect memory if a slow client falls behind.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| SignalR | Adds a significant library dependency; provides bidirectional RPC that is not needed here. SSE covers the use case with zero additional packages. |
+| Raw WebSockets | More complex handshake and framing to implement manually; no auto-reconnect in browsers; still requires a library for production-quality use. |
+| Polling | Simple but adds unnecessary latency to countdown display and wastes bandwidth on a battery-powered event laptop. |

--- a/docs/adr/0003-pnpm-for-supply-chain-security.md
+++ b/docs/adr/0003-pnpm-for-supply-chain-security.md
@@ -1,0 +1,32 @@
+# 0003. pnpm as frontend package manager
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+The frontend (React + TypeScript + Vite) requires a JavaScript package manager. Supply-chain security is an explicit concern: malicious or compromised transitive dependencies are a real risk in the npm ecosystem. The project also targets Windows as primary deployment, so cross-platform behaviour of the package manager matters.
+
+## Decision
+
+Use **pnpm** as the package manager for `src/PhotoBooth.Web/`.
+
+pnpm's strict `node_modules` layout (symlinked, content-addressed store) prevents packages from silently importing modules they did not declare as dependencies — a class of supply-chain vulnerability that npm's flat `node_modules` allows. The lockfile (`pnpm-lock.yaml`) pins exact content hashes for all transitive dependencies.
+
+Additionally, pnpm's workspace and overrides mechanism (`pnpm.overrides` in `package.json`) makes it straightforward to apply security pins on transitive dependencies flagged by Dependabot without waiting for upstream patches.
+
+## Consequences
+
+- All contributors and CI must have pnpm installed (listed as a prerequisite in `README.md`).
+- `pnpm-lock.yaml` is the authoritative lockfile; `package-lock.json` is not present.
+- Transitive dependency security pins can be applied cleanly via `pnpm.overrides`.
+- Phantom dependency access is prevented by design, which occasionally surfaces as import errors for packages that npm/yarn would have silently exposed.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| npm | Flat `node_modules` allows phantom dependencies; no content-addressed store by default; weaker supply-chain guarantees. |
+| yarn (classic) | Same flat layout issue as npm; classic yarn is in maintenance mode. |
+| yarn berry (PnP) | Strong supply-chain story but Plug'n'Play mode has compatibility friction with some Vite/build-tool plugins; additional complexity for limited benefit over pnpm. |

--- a/docs/adr/0004-per-user-msi-and-user-settings.md
+++ b/docs/adr/0004-per-user-msi-and-user-settings.md
@@ -1,0 +1,37 @@
+# 0004. Per-user MSI install and appsettings.User.json for upgrade-safe configuration
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+PhotoBooth is installed on event laptops by non-technical operators who may not have administrator rights. Upgrades should be frictionless and must not overwrite operator-specific configuration (camera model, event name, storage path).
+
+Standard ASP.NET Core practice is to ship a default `appsettings.json` that gets overwritten on upgrade, with no built-in mechanism for preserving local changes.
+
+## Decision
+
+**Installer scope:** The WiX v5 MSI installer (`installer/PhotoBooth.Installer/`) uses `Scope="perUser"`, installing to `%LOCALAPPDATA%\PhotoBooth`. No UAC elevation prompt is shown; no administrator rights are required.
+
+**Configuration layering:** On startup, the server loads configuration from two files in the install directory:
+1. `appsettings.json` — shipped defaults, overwritten on every upgrade.
+2. `appsettings.User.json` — operator overrides, never touched by the installer.
+
+Operators place only the settings they want to change in `appsettings.User.json`. The files are merged by ASP.NET Core's configuration system; keys in `appsettings.User.json` win.
+
+## Consequences
+
+- Upgrades are safe: operators run the new MSI, their customisations survive.
+- No admin prompt on installation or upgrade; suitable for locked-down event machines.
+- Operators must not edit `appsettings.json` directly — the `README.md` calls this out explicitly.
+- If `appsettings.User.json` contains a key that is removed in a future version, the orphaned key is silently ignored by .NET's configuration system (no error, no warning).
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Per-machine MSI (ALLUSERS=1) | Requires admin rights / UAC — impractical for event laptops managed by non-IT staff. |
+| Edit appsettings.json in place | Overwritten on upgrade, causing silent config loss. |
+| Environment variables for overrides | Harder to discover and edit for non-technical operators; not persisted across reboots without additional OS setup. |
+| Separate config UI | Adds significant UI development scope; a JSON file is sufficient given the operator profile. |

--- a/docs/adr/0005-guest-route-security-model.md
+++ b/docs/adr/0005-guest-route-security-model.md
@@ -1,0 +1,47 @@
+# 0005. Guest-route security model (salted URL prefix, no auth)
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+PhotoBooth runs on a local Wi-Fi network at events. Two distinct audiences access it:
+
+- **Operator**: runs the booth, triggers captures, has physical access to the machine.
+- **Guests**: browse and download their photos on their phones, connected to the same Wi-Fi.
+
+Guests should not be able to trigger captures or access the booth operator page. Requiring guests to log in (username/password, OAuth, etc.) adds friction that would defeat the purpose of an event photo booth — guests expect to scan a QR code and immediately see their photos.
+
+Additionally, if the event's photos are embarrassing or private, the app should not be trivially discoverable by anyone who finds the server's IP.
+
+No public internet exposure is involved; HSTS is inappropriate because the IP address changes between events.
+
+## Decision
+
+Use a layered, no-login security model:
+
+1. **Localhost restriction** (`LocalhostOnlyFilter`): The booth page (`/`), the capture API (`/api/photos/capture`), and the trigger API (`/api/photos/trigger`) only respond to requests from `127.0.0.1` / `::1`. External access returns HTTP 403. Configurable per endpoint via `Booth.RestrictToLocalhost`, `Capture.RestrictToLocalhost`, `Trigger.RestrictToLocalhost`.
+
+2. **Salted URL prefix** for guest routes: Guest-facing routes (`/{prefix}/download`, `/{prefix}/gallery`, etc.) are prefixed with a short hash derived from `SHA256(eventName + salt)`. The salt is set by the operator in `appsettings.User.json` (`UrlPrefix:Salt`). This means the URLs are not guessable without knowing the salt, and changing the salt or event name invalidates old URLs (useful after an event ends).
+
+3. **Security headers + rate limiting**: All responses include CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers (`SecurityHeadersMiddleware`). Capture and trigger endpoints are rate-limited (default: 5 requests per 10-second window).
+
+4. **No HSTS**: The app runs over HTTP on a dynamic LAN IP; HSTS would lock browsers to an IP/hostname that changes between events.
+
+## Consequences
+
+- Guests get a frictionless experience: scan QR code, browse photos, download.
+- The booth operator page and capture APIs are not accessible from guest devices.
+- Guest URLs are obscure but not secret — anyone who sees the QR code can share the URL. This is intentional: guests sharing the URL with friends at the event is fine.
+- Operators must distribute the QR code / URL to guests; the app itself does not do user management.
+- An empty `UrlPrefix:Salt` still produces a deterministic (but weaker) prefix based on event name alone.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Login/password for guests | Kills the "scan and go" UX that makes photo booths work at events. |
+| Per-photo access tokens | Significantly more complex; guests would need to carry tokens across sessions. |
+| VPN / network segmentation | Requires IT infrastructure the operator typically does not have at a venue. |
+| HTTPS + HSTS | Dynamic LAN IPs make certificate management impractical without a domain name; HSTS on IP addresses is not supported by browsers. |

--- a/docs/adr/0006-sequential-code-generation.md
+++ b/docs/adr/0006-sequential-code-generation.md
@@ -1,0 +1,32 @@
+# 0006. Sequential numeric codes for photo download
+
+**Status:** Accepted
+
+**Date:** 2024-01-01 (retroactive)
+
+## Context
+
+After a photo is taken, guests need a way to retrieve it on their phones. The booth displays a QR code and a short numeric code. Guests who cannot scan a QR code (older phone, poor lighting) type the numeric code into the download URL manually.
+
+The code must be unique within an event, short enough to type without error, and generated without a separate coordination service.
+
+## Decision
+
+Use `SequentialCodeGenerator` as the default `IPhotoCodeGenerator`. It assigns codes `1`, `2`, `3`, … by incrementing the current photo count. The code for photo N is always `N` (count + 1 at capture time).
+
+Because the count only ever increases, codes are inherently unique — the `isCodeTaken` callback on `IPhotoCodeGenerator.GenerateUniqueCodeAsync` is not needed and is intentionally ignored.
+
+## Consequences
+
+- Codes are as short as possible (1–3 digits for a typical event), minimising transcription errors.
+- Guests can tell the operator "I'm photo number 42" unambiguously.
+- Code generation is O(1) with no coordination or locking beyond the existing photo-count query.
+- Codes are sequential and therefore enumerable: a guest could guess neighbouring codes and see other guests' photos. This is accepted — the download URL is already obscure (salted prefix, ADR 0005), and event photos are generally not considered sensitive. If strict isolation were needed, a different generator could be registered.
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|-------------|-------------|
+| Random short codes (e.g., 6 alphanumeric chars) | Harder to type or read aloud; collision probability requires a retry loop; no meaningful benefit for typical event sizes (< 1 000 photos). |
+| UUID / GUID | Far too long to type manually. |
+| QR-only (no typed code) | QR scanning fails in poor lighting or on older devices; typed fallback is a real accessibility need. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,41 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the PhotoBooth project.
+
+An ADR captures a significant architectural choice — the context that drove it, what was decided, and what alternatives were rejected. The goal is to make future maintenance less archaeological: instead of reverse-engineering *why* things are the way they are, read the relevant ADR.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| Accepted | Decision is in effect |
+| Superseded by [NNNN](NNNN-title.md) | Replaced by a later decision |
+| Deprecated | Still in place but no longer recommended |
+
+## When to write an ADR
+
+Write one whenever you make a decision that is:
+
+- **Consequential** — hard to reverse or costly to change later
+- **Non-obvious** — a future reader might reasonably wonder "why not X?"
+- **Cross-cutting** — affects multiple layers or components
+
+Routine implementation choices (which utility method to use, how to name a variable) don't need ADRs.
+
+## How to add one
+
+1. Copy `0000-template.md` and number it sequentially.
+2. Fill in all sections. "Alternatives considered" is the most important — it prevents future contributors from re-litigating already-resolved trade-offs.
+3. Set status to `Accepted`.
+4. Add a one-line entry to this README's index below.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-clean-architecture-layers.md) | Clean architecture with four layers | Accepted |
+| [0002](0002-sse-for-realtime-events.md) | Server-Sent Events for real-time event broadcasting | Accepted |
+| [0003](0003-pnpm-for-supply-chain-security.md) | pnpm as frontend package manager | Accepted |
+| [0004](0004-per-user-msi-and-user-settings.md) | Per-user MSI install and appsettings.User.json | Accepted |
+| [0005](0005-guest-route-security-model.md) | Guest-route security model (salted URL prefix, no auth) | Accepted |
+| [0006](0006-sequential-code-generation.md) | Sequential numeric codes for photo download | Accepted |


### PR DESCRIPTION
## Summary

- Establishes `docs/adr/` with a MADR-lite template and index README
- Adds six retroactive ADRs covering the key non-obvious architectural decisions:
  - 0001: Clean 4-layer architecture (Domain / Application / Infrastructure / Server)
  - 0002: SSE for real-time event broadcasting (vs. SignalR / WebSockets)
  - 0003: pnpm as package manager for supply-chain security
  - 0004: Per-user MSI install and `appsettings.User.json` for upgrade-safe config
  - 0005: Guest-route security model (salted URL prefix, localhost restriction, no login)
  - 0006: Sequential numeric download codes (vs. random / UUID)
- Adds cross-references in `README.md` and `CLAUDE.md` (including a note to write an ADR for future consequential decisions)

## Test plan

- [ ] Verify `docs/adr/` renders correctly on GitHub (links in the index README resolve)
- [ ] Confirm no build or test impact (`dotnet build` / `dotnet test` unchanged)

Generated with [Claude Code](https://claude.com/claude-code)