### PR TITLE
Harden guest photo access: per-IP code-lookup throttling and adb config validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,8 @@ All responses include security headers added by `SecurityHeadersMiddleware` (CSP
 
 `/api/photos/capture` and `/api/photos/trigger` are rate-limited (default: 5 requests per 10-second fixed window, configurable via `RateLimiting:PermitLimit` and `RateLimiting:WindowSeconds`). Returns HTTP 429 when exceeded.
 
+The public photo-code lookup `GET /api/photos/{code}` has a separate **per-IP** fixed-window limiter (`"lookup"` policy, default 10 per 10s via `RateLimiting:Lookup:PermitLimit`/`WindowSeconds`) to make scripted enumeration of sequential download codes (ADR 0006) impractical. The image (`/{id}/image`) and list (`/`) endpoints are intentionally **not** throttled, so the gallery, slideshow, and the bulk export script (`scripts/download-event.sh`, which fetches by list + GUID, never by code) are unaffected.
+
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ You can delete `appsettings.json` to restore defaults on next startup, or delete
   },
   "RateLimiting": {
     "PermitLimit": 5,
-    "WindowSeconds": 10
+    "WindowSeconds": 10,
+    "Lookup": {
+      "PermitLimit": 10,
+      "WindowSeconds": 10
+    }
   }
 }
 ```
@@ -187,8 +191,10 @@ Requires [ADB](https://developer.android.com/tools/adb) installed and an Android
 - `Event.Name`: Event name used as storage subfolder (defaults to current date)
 - `Slideshow.SwirlEffect`: Enable swirl animation effect on slideshow (default: true)
 - `Slideshow.IntervalMs`: Interval in ms between slideshow transitions (default: 30000)
-- `RateLimiting.PermitLimit`: Max requests per rate limit window (default: 5)
+- `RateLimiting.PermitLimit`: Max `/capture` and `/trigger` requests per rate limit window (default: 5)
 - `RateLimiting.WindowSeconds`: Rate limit window duration in seconds (default: 10)
+- `RateLimiting.Lookup.PermitLimit`: Max photo-code lookups (`GET /api/photos/{code}`) per window, **per client IP**, to make scripted enumeration of sequential codes impractical (default: 10). The image and list endpoints are not throttled, so the gallery and the bulk export script are unaffected.
+- `RateLimiting.Lookup.WindowSeconds`: Lookup rate limit window duration in seconds (default: 10)
 
 ## Project Structure
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -97,6 +97,8 @@ Each photo gets a unique, short, human-friendly code:
 - Displayed on photo during slideshow
 - Valid for the duration of the event
 
+The code-lookup endpoint (`GET /api/photos/{code}`) is rate-limited per client IP (default 10 per 10s) so the sequential codes cannot be cheaply enumerated. The bulk export script downloads by photo list + GUID rather than by code, so it is unaffected by this limit. See ADR 0006 for the rationale behind sequential codes and the residual exposure.
+
 ### QR Codes
 
 Optional QR code overlay on slideshow photos:

--- a/docs/adr/0006-sequential-code-generation.md
+++ b/docs/adr/0006-sequential-code-generation.md
@@ -22,6 +22,8 @@ Because the count only ever increases, codes are inherently unique — the `isCo
 - Guests can tell the operator "I'm photo number 42" unambiguously.
 - Code generation is O(1) with no coordination or locking beyond the existing photo-count query.
 - Codes are sequential and therefore enumerable: a guest could guess neighbouring codes and see other guests' photos. This is accepted — the download URL is already obscure (salted prefix, ADR 0005), and event photos are generally not considered sensitive. If strict isolation were needed, a different generator could be registered.
+- To raise the cost of *scripted* enumeration without abandoning short codes, the code-lookup endpoint (`GET /api/photos/{code}`) carries a per-IP fixed-window rate limit (the `"lookup"` policy; default 10 per 10s). This throttles a single client walking the code space while leaving legitimate guests, the gallery, the slideshow, and the bulk export script unaffected — the export script and gallery fetch the full photo list and download by GUID (`GET /api/photos/{id}/image`), never via the code lookup, so those paths are intentionally not throttled.
+- Residual limitation: the list endpoint (`GET /api/photos/`) already returns every photo's GUID and code to any LAN client, and photos are shown in a public slideshow by design, so throttling the code lookup does not make photos private — consistent with the stance above that event photos are not treated as sensitive.
 
 ## Alternatives considered
 

--- a/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
+++ b/src/PhotoBooth.Infrastructure/Camera/AndroidCameraOptions.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace PhotoBooth.Infrastructure.Camera;
 
 /// <summary>
@@ -91,4 +93,31 @@ public class AndroidCameraOptions
     /// Seconds to wait for the capture lock before reporting camera busy.
     /// </summary>
     public int CaptureLockTimeoutSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Validates options that are interpolated into <c>adb shell</c> commands, rejecting
+    /// values that could carry shell metacharacters. <see cref="PinCode"/> and
+    /// <see cref="CameraAction"/> are trusted config-time inputs, but validating them here
+    /// keeps an injection footgun closed if config is ever templated or operator-supplied.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when a value is unsafe to pass to a device shell.</exception>
+    public void Validate()
+    {
+        // PIN is typed via "adb shell input text {pin}"; restrict to digits.
+        if (PinCode is not null && !Regex.IsMatch(PinCode, "^[0-9]+$"))
+        {
+            throw new InvalidOperationException(
+                "Camera:Android:PinCode must contain digits only.");
+        }
+
+        // CameraAction is interpolated into "adb shell am start -a android.media.action.{action}".
+        // Android action suffixes are letters, digits and underscores; this charset excludes
+        // shell metacharacters (spaces, ; $ ` & | etc.) that would enable command injection.
+        if (!Regex.IsMatch(CameraAction, "^[A-Za-z0-9_]+$"))
+        {
+            throw new InvalidOperationException(
+                $"Camera:Android:CameraAction '{CameraAction}' is invalid. " +
+                "It must contain only letters, digits and underscores (e.g. STILL_IMAGE_CAMERA).");
+        }
+    }
 }

--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -32,7 +32,8 @@ public static class PhotoEndpoints
             .WithName("GetAllPhotos");
 
         group.MapGet("/{code}", GetPhotoByCode)
-            .WithName("GetPhotoByCode");
+            .WithName("GetPhotoByCode")
+            .RequireRateLimiting("lookup");
 
         group.MapGet("/{id:guid}/image", GetPhotoImage)
             .WithName("GetPhotoImage");

--- a/src/PhotoBooth.Server/Program.cs
+++ b/src/PhotoBooth.Server/Program.cs
@@ -69,6 +69,7 @@ switch (cameraProvider.ToLowerInvariant())
     case "android":
         var androidOptions = new AndroidCameraOptions();
         builder.Configuration.GetSection("Camera:Android").Bind(androidOptions);
+        androidOptions.Validate();
         builder.Services.AddSingleton<ICameraProvider>(sp =>
         {
             var adbLogger = sp.GetRequiredService<ILogger<AdbService>>();
@@ -163,6 +164,11 @@ builder.Services.AddCors(options =>
 // Add rate limiting for capture endpoints
 var rateLimitPermitLimit = builder.Configuration.GetValue<int?>("RateLimiting:PermitLimit") ?? 5;
 var rateLimitWindowSeconds = builder.Configuration.GetValue<int?>("RateLimiting:WindowSeconds") ?? 10;
+// Per-IP throttling for the public photo-code lookup, to make scripted enumeration of
+// sequential download codes (see ADR 0006) impractical without affecting the gallery,
+// the image endpoint, or the bulk export script (which fetch by list + GUID, not by code).
+var lookupPermitLimit = builder.Configuration.GetValue<int?>("RateLimiting:Lookup:PermitLimit") ?? 10;
+var lookupWindowSeconds = builder.Configuration.GetValue<int?>("RateLimiting:Lookup:WindowSeconds") ?? 10;
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
@@ -172,6 +178,15 @@ builder.Services.AddRateLimiter(options =>
         limiter.Window = TimeSpan.FromSeconds(rateLimitWindowSeconds);
         limiter.QueueLimit = 0;
     });
+    options.AddPolicy("lookup", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = lookupPermitLimit,
+                Window = TimeSpan.FromSeconds(lookupWindowSeconds),
+                QueueLimit = 0,
+            }));
 });
 
 var app = builder.Build();

--- a/src/PhotoBooth.Server/appsettings.json
+++ b/src/PhotoBooth.Server/appsettings.json
@@ -165,7 +165,15 @@
     // Maximum requests per window
     "PermitLimit": 5,
     // Fixed window duration in seconds
-    "WindowSeconds": 10
+    "WindowSeconds": 10,
+    // Per-IP throttling for the public photo-code lookup (GET /api/photos/{code}),
+    // to make scripted enumeration of sequential download codes impractical
+    "Lookup": {
+      // Maximum lookups per window, per client IP
+      "PermitLimit": 10,
+      // Fixed window duration in seconds
+      "WindowSeconds": 10
+    }
   },
 
   // Watchdog settings

--- a/tests/PhotoBooth.Infrastructure.Tests/Camera/AndroidCameraOptionsTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Camera/AndroidCameraOptionsTests.cs
@@ -1,0 +1,69 @@
+using PhotoBooth.Infrastructure.Camera;
+
+namespace PhotoBooth.Infrastructure.Tests.Camera;
+
+[TestClass]
+public sealed class AndroidCameraOptionsTests
+{
+    [TestMethod]
+    public void Validate_DefaultOptions_DoesNotThrow()
+    {
+        var options = new AndroidCameraOptions();
+
+        options.Validate();
+    }
+
+    [TestMethod]
+    public void Validate_NumericPin_DoesNotThrow()
+    {
+        var options = new AndroidCameraOptions { PinCode = "1234" };
+
+        options.Validate();
+    }
+
+    [TestMethod]
+    public void Validate_NullPin_DoesNotThrow()
+    {
+        var options = new AndroidCameraOptions { PinCode = null };
+
+        options.Validate();
+    }
+
+    [TestMethod]
+    [DataRow("12ab")]
+    [DataRow("12 34")]
+    [DataRow("1234; reboot")]
+    public void Validate_NonNumericPin_Throws(string pin)
+    {
+        var options = new AndroidCameraOptions { PinCode = pin };
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => options.Validate());
+        Assert.Contains("PinCode", ex.Message);
+    }
+
+    [TestMethod]
+    [DataRow("STILL_IMAGE_CAMERA")]
+    [DataRow("IMAGE_CAPTURE")]
+    [DataRow("VIDEO_CAMERA2")]
+    public void Validate_ValidCameraAction_DoesNotThrow(string action)
+    {
+        var options = new AndroidCameraOptions { CameraAction = action };
+
+        options.Validate();
+    }
+
+    [TestMethod]
+    [DataRow("STILL_IMAGE_CAMERA; rm -rf /")]
+    [DataRow("$(reboot)")]
+    [DataRow("FOO`whoami`")]
+    [DataRow("FOO BAR")]
+    [DataRow("FOO|BAR")]
+    [DataRow("")]
+    public void Validate_UnsafeCameraAction_Throws(string action)
+    {
+        var options = new AndroidCameraOptions { CameraAction = action };
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => options.Validate());
+        Assert.Contains("CameraAction", ex.Message);
+    }
+}

--- a/tests/PhotoBooth.Server.Tests/RateLimitingTests.cs
+++ b/tests/PhotoBooth.Server.Tests/RateLimitingTests.cs
@@ -63,4 +63,43 @@ public sealed class RateLimitingTests
         var limitedResponse = await _client.PostAsync("/api/photos/capture", null);
         Assert.AreEqual(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
     }
+
+    [TestMethod]
+    public async Task CodeLookupEndpoint_Returns429AfterExceedingRateLimit()
+    {
+        // The lookup limit is 10 per window (rate limiting runs before the handler, so a
+        // missing code returns 404 but still consumes the quota).
+        for (var i = 0; i < 10; i++)
+        {
+            var response = await _client.GetAsync($"/api/photos/{i}");
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode, $"Lookup {i + 1} should pass the limiter");
+        }
+
+        // The 11th lookup should be rate-limited.
+        var limitedResponse = await _client.GetAsync("/api/photos/999");
+        Assert.AreEqual(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task ImageEndpoint_IsNotRateLimited()
+    {
+        // The bulk export script (scripts/download-event.sh) downloads every photo via this
+        // endpoint, so it must not be throttled. Exceed the lookup limit and assert no 429.
+        for (var i = 0; i < 15; i++)
+        {
+            var response = await _client.GetAsync($"/api/photos/{Guid.NewGuid()}/image");
+            Assert.AreNotEqual(HttpStatusCode.TooManyRequests, response.StatusCode, $"Image request {i + 1} should not be throttled");
+        }
+    }
+
+    [TestMethod]
+    public async Task ListEndpoint_IsNotRateLimited()
+    {
+        // The gallery and the export script fetch the full list; it must not be throttled.
+        for (var i = 0; i < 15; i++)
+        {
+            var response = await _client.GetAsync("/api/photos/");
+            Assert.AreNotEqual(HttpStatusCode.TooManyRequests, response.StatusCode, $"List request {i + 1} should not be throttled");
+        }
+    }
 }


### PR DESCRIPTION
Group E from the codebase health check (#241). Two security refinements to the guest-facing surface, in one PR.

## #254 — Per-IP throttling on the code lookup
Sequential download codes (ADR 0006) plus an unthrottled GET /api/photos/{code} let a guest on the LAN walk the code space and pull every photo's GUID.

- New per-IP fixed-window rate limiter (the lookup policy, default 10 per 10s, configurable via RateLimiting:Lookup:PermitLimit / WindowSeconds). Per-IP, unlike the existing global capture policy, so one abuser cannot exhaust everyone's budget.
- Applied to GET /api/photos/{code} only. The image and list endpoints stay unthrottled, so the gallery, slideshow, and the bulk export script (scripts/download-event.sh — fetches by list + GUID, never by code) are unaffected.
- We keep the short, typeable sequential codes; ADR 0006 accepts their enumerability as an intentional usability tradeoff. ADR updated with the mitigation and the residual list-endpoint exposure.

## #255 — adb config validation
AndroidCameraOptions.PinCode and .CameraAction were interpolated straight into adb shell commands with no validation.

- AndroidCameraOptions.Validate() rejects a non-digit PinCode and any CameraAction containing shell metacharacters, called at startup in the android provider branch so misconfiguration fails fast with a clear, key-named error.

## Tests
- 3 new lookup integration tests (429 after the limit; image and list endpoints not throttled).
- New AndroidCameraOptionsTests unit class (runs in CI).
- Full CI suite green.

## Docs
ADR 0006, README, SPEC, and CLAUDE.md updated for the new lookup policy.

Closes #254
Closes #255