### PR TITLE
ci/build hygiene: unify pnpm, pin SDK, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig — cross-editor formatting consistency.
+# Captures existing project conventions only (formatting/whitespace).
+# Intentionally no .NET analyzer / code-style rules: EnforceCodeStyleInBuild
+# + TreatWarningsAsErrors (Directory.Build.props) would turn any such rule into
+# a build break. Code style stays enforced by the compiler as before.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.cs]
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,json,css,html,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
+        with:
+          package_json_file: src/PhotoBooth.Web/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
+        with:
+          package_json_file: src/PhotoBooth.Web/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/PhotoBooth.Web/package.json
+++ b/src/PhotoBooth.Web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.8.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
Group C of the codebase health check (#241): three low-risk CI/build-hygiene improvements, all touching build/CI configuration.

## #248 — Unify pnpm across CI and release
Added `"packageManager": "pnpm@11.8.0"` to src/PhotoBooth.Web/package.json as the single source of truth, and removed the divergent `version:` inputs from both workflows (CI was 11, release was 9). pnpm/action-setup now derives the version from the field, so CI and release install the same pnpm.

## #249 — Pin the .NET SDK
Added global.json pinning the SDK to 10.0.301 with `rollForward: latestMinor`, keeping local and CI toolchains aligned while staying compatible with CI's `dotnet-version: 10.0.x`.

## #250 — Add .editorconfig
Added an .editorconfig capturing the existing conventions (C# 4-space; TS/JS/JSON/CSS/YAML 2-space; LF; trim trailing whitespace; final newline). Formatting only — no .NET analyzer/code-style rules, to avoid turning style into a build break under EnforceCodeStyleInBuild + TreatWarningsAsErrors.

## Verification
- `dotnet --version` resolves to 10.0.301 (global.json honored); `dotnet build` clean (0 warnings) and all 114 unit tests pass — confirms the SDK pin and that .editorconfig introduces no build-breaking style errors.
- Frontend pnpm install/lint/build verified by the CI `frontend` job (pnpm unavailable locally).

Closes #248
Closes #249
Closes #250