### PR TITLE
Group D: photo storage and capture resilience (#251, #252, #253)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,10 @@ Clean architecture with four layers:
 
 - `SequentialCodeGenerator` (default): Assigns sequential numeric codes (1, 2, 3, ...) based on photo count
 
+### Storage Assumptions
+
+`FileSystemPhotoRepository` is registered as a singleton and caches the photo list in memory. The cache is loaded once (lazily) and only appended to on save. This assumes **a single booth process owns the storage directory for the duration of one event**. Photos deleted on disk externally, or writes from a second process sharing the directory, are not reflected without restarting the process. If a multi-process or shared-directory scenario ever becomes a requirement, add a cache-invalidation strategy (TTL re-scan, `FileSystemWatcher`, or an operator-triggered refresh).
+
 ## Tech Stack
 
 - **Backend**: C# / .NET 10, ASP.NET Core minimal APIs

--- a/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
+++ b/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using PhotoBooth.Application.DTOs;
 using PhotoBooth.Application.Events;
+using PhotoBooth.Domain.Exceptions;
 using PhotoBooth.Domain.Interfaces;
 
 namespace PhotoBooth.Application.Services;
@@ -82,7 +83,7 @@ public class CaptureWorkflowService : ICaptureWorkflowService
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Failed to broadcast timeout event");
+                _logger.LogWarning(ex, "Failed to broadcast timeout event");
             }
         }
 
@@ -127,6 +128,13 @@ public class CaptureWorkflowService : ICaptureWorkflowService
         {
             _logger.LogInformation("Capture workflow cancelled during shutdown for trigger from {Source}", triggerSource);
             throw;
+        }
+        catch (StorageException ex)
+        {
+            _logger.LogError(ex, "Capture failed: could not save photo to storage");
+            await _eventBroadcaster.BroadcastAsync(
+                new CaptureFailedEvent("Could not save photo — storage may be full or unavailable"),
+                cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/PhotoBooth.Domain/Exceptions/StorageException.cs
+++ b/src/PhotoBooth.Domain/Exceptions/StorageException.cs
@@ -1,0 +1,12 @@
+namespace PhotoBooth.Domain.Exceptions;
+
+public class StorageException : PhotoBoothException
+{
+    public StorageException(string message) : base(message)
+    {
+    }
+
+    public StorageException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
+++ b/src/PhotoBooth.Infrastructure/Storage/FileSystemPhotoRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using PhotoBooth.Domain.Entities;
+using PhotoBooth.Domain.Exceptions;
 using PhotoBooth.Domain.Interfaces;
 
 namespace PhotoBooth.Infrastructure.Storage;
@@ -9,6 +10,11 @@ public class FileSystemPhotoRepository : IPhotoRepository
     private readonly string _storagePath;
     private readonly ILogger<FileSystemPhotoRepository>? _logger;
     private readonly SemaphoreSlim _lock = new(1, 1);
+
+    // The cache assumes a single booth process owns this storage directory for the
+    // duration of one event. It is loaded once (lazily) and only appended to on save;
+    // photos deleted on disk externally, or writes from a second process sharing the
+    // directory, are not reflected without restarting the process. See CLAUDE.md.
     private List<Photo>? _photosCache;
 
     public FileSystemPhotoRepository(string basePath, string eventName, ILogger<FileSystemPhotoRepository>? logger = null)
@@ -34,7 +40,16 @@ public class FileSystemPhotoRepository : IPhotoRepository
             var fileName = $"{paddedCode}-{photo.Id}.jpg";
             var updatedPhoto = photo with { FilePath = Path.Combine(_storagePath, fileName) };
 
-            await File.WriteAllBytesAsync(updatedPhoto.FilePath, imageData, cancellationToken);
+            try
+            {
+                await File.WriteAllBytesAsync(updatedPhoto.FilePath, imageData, cancellationToken);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                throw new StorageException(
+                    $"Failed to save photo to storage — the disk may be full or the directory read-only (path: {_storagePath})",
+                    ex);
+            }
 
             // Add to cache if it exists
             _photosCache?.Add(updatedPhoto);

--- a/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
+++ b/src/PhotoBooth.Server/Endpoints/PhotoEndpoints.cs
@@ -77,6 +77,13 @@ public static class PhotoEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable,
                 title: "Camera Not Available");
         }
+        catch (StorageException ex)
+        {
+            return Results.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status507InsufficientStorage,
+                title: "Storage Unavailable");
+        }
     }
 
     private static async Task<IResult> GetPhotoByCode(

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -16,6 +16,12 @@ const DEFAULT_WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000;
 const ERROR_DISPLAY_MS = 3000;
 const FADE_DURATION_MS = 500;
 const GAMEPAD_DEBUG_DISPLAY_MS = 3000;
+// Client-side fallback: if a countdown-started never receives a terminal event
+// (photo-captured / capture-failed) — e.g. the server's failure broadcast itself
+// failed — reset the stuck UI after this long. Must exceed the server's max workflow
+// timeout (Capture:CountdownDurationMs + Capture:BufferTimeoutHighLatencyMs, up to ~52s
+// for Android over ADB) to avoid false positives on slow but legitimate captures.
+const CAPTURE_WATCHDOG_MS = 60000;
 
 interface BoothPageProps {
   qrCodeBaseUrl?: string;
@@ -55,6 +61,9 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
   const previewTimeoutRef = useRef<number | null>(null);
   const errorTimeoutRef = useRef<number | null>(null);
   const gamepadDebugTimeoutRef = useRef<number | null>(null);
+  // FIFO of pending capture watchdog timers, one armed per countdown-started and
+  // cancelled (oldest first) when a terminal event arrives.
+  const captureWatchdogsRef = useRef<number[]>([]);
   const photoKeyRef = useRef(0);
   // Track the current display for use in callbacks (avoid stale closure)
   const currentDisplayRef = useRef<DisplayPhoto | null>(null);
@@ -96,6 +105,15 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
       }
     };
   }, [resetWatchdog]);
+
+  // Cancel any pending capture watchdogs on unmount
+  useEffect(() => {
+    const watchdogs = captureWatchdogsRef.current;
+    return () => {
+      watchdogs.forEach(clearTimeout);
+      watchdogs.length = 0;
+    };
+  }, []);
 
   // Keep refs in sync with state
   useEffect(() => {
@@ -195,19 +213,53 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
     setCurrentDisplay(null);
   }, []);
 
+  // Show an error message that auto-dismisses after ERROR_DISPLAY_MS.
+  const showTransientError = useCallback((message: string) => {
+    setErrorMessage(message);
+    if (errorTimeoutRef.current !== null) {
+      clearTimeout(errorTimeoutRef.current);
+    }
+    errorTimeoutRef.current = window.setTimeout(() => {
+      setErrorMessage(null);
+    }, ERROR_DISPLAY_MS);
+  }, []);
+
+  // Cancel the oldest pending capture watchdog (a terminal event arrived for it).
+  const clearOldestCaptureWatchdog = useCallback(() => {
+    const timerId = captureWatchdogsRef.current.shift();
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+  }, []);
+
   const handleEvent = useCallback((event: PhotoBoothEvent) => {
     switch (event.eventType) {
-      case 'countdown-started':
+      case 'countdown-started': {
         console.log('Countdown started, duration:', event.durationMs);
         setCountdownDurationMs(event.durationMs);
         setActiveCountdowns(count => count + 1);
 
+        // Arm a watchdog so a missing terminal event can't leave the UI stuck on
+        // the countdown. On fire it releases one countdown and surfaces a timeout.
+        const watchdogId = window.setTimeout(() => {
+          const index = captureWatchdogsRef.current.indexOf(watchdogId);
+          if (index !== -1) {
+            captureWatchdogsRef.current.splice(index, 1);
+          }
+          console.warn('Capture watchdog fired: no terminal event received, resetting UI');
+          setActiveCountdowns(count => Math.max(0, count - 1));
+          showTransientError('Capture timed out');
+        }, CAPTURE_WATCHDOG_MS);
+        captureWatchdogsRef.current.push(watchdogId);
+
         // Interrupt current display if any
         handleInterruption();
         break;
+      }
 
       case 'photo-captured': {
         console.log('Photo captured:', event.code);
+        clearOldestCaptureWatchdog();
         setActiveCountdowns(count => Math.max(0, count - 1));
 
         const newPhoto: QueuedPhoto = {
@@ -224,17 +276,12 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
 
       case 'capture-failed':
         console.error('Capture failed:', event.error);
+        clearOldestCaptureWatchdog();
         setActiveCountdowns(count => Math.max(0, count - 1));
-        setErrorMessage(event.error);
-        if (errorTimeoutRef.current !== null) {
-          clearTimeout(errorTimeoutRef.current);
-        }
-        errorTimeoutRef.current = window.setTimeout(() => {
-          setErrorMessage(null);
-        }, ERROR_DISPLAY_MS);
+        showTransientError(event.error);
         break;
     }
-  }, [handleInterruption, startShowingPhoto]);
+  }, [handleInterruption, startShowingPhoto, showTransientError, clearOldestCaptureWatchdog]);
 
   useEventStream(handleEvent);
 
@@ -246,15 +293,9 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
       await triggerCapture(durationMs);
     } catch (err) {
       console.error('Trigger error:', err);
-      setErrorMessage(err instanceof Error ? err.message : 'Failed to trigger capture');
-      if (errorTimeoutRef.current !== null) {
-        clearTimeout(errorTimeoutRef.current);
-      }
-      errorTimeoutRef.current = window.setTimeout(() => {
-        setErrorMessage(null);
-      }, ERROR_DISPLAY_MS);
+      showTransientError(err instanceof Error ? err.message : 'Failed to trigger capture');
     }
-  }, [resetWatchdog]);
+  }, [resetWatchdog, showTransientError]);
 
   // Clear queue and dismiss current display
   const clearQueueAndDisplay = useCallback(() => {

--- a/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
@@ -173,4 +173,28 @@ describe('BoothPage', () => {
     act(() => { vi.advanceTimersByTime(1000); });
     expect(reloadMock).toHaveBeenCalled();
   });
+
+  it('clears a stuck countdown and shows a timeout error when no terminal event arrives', () => {
+    // Inactivity watchdog set well above the capture watchdog so it does not interfere.
+    render(<BoothPage watchdogTimeoutMs={300000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    expect(screen.getByTestId('capture-overlay')).toBeInTheDocument();
+
+    // Advance past CAPTURE_WATCHDOG_MS (60000) with no photo-captured / capture-failed.
+    act(() => { vi.advanceTimersByTime(60000); });
+
+    expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
+    expect(screen.getByText('Capture timed out')).toBeInTheDocument();
+  });
+
+  it('does not fire the capture watchdog when a terminal event arrives in time', () => {
+    render(<BoothPage watchdogTimeoutMs={300000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    act(() => { capturedOnEvent!(photoCapturedEvent()); });
+
+    // Advancing past the watchdog window must not surface a timeout error.
+    act(() => { vi.advanceTimersByTime(60000); });
+
+    expect(screen.queryByText('Capture timed out')).not.toBeInTheDocument();
+  });
 });

--- a/tests/PhotoBooth.Infrastructure.Tests/FileSystemPhotoRepositoryTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/FileSystemPhotoRepositoryTests.cs
@@ -1,4 +1,5 @@
 using PhotoBooth.Domain.Entities;
+using PhotoBooth.Domain.Exceptions;
 using PhotoBooth.Infrastructure.Storage;
 
 namespace PhotoBooth.Infrastructure.Tests;
@@ -199,5 +200,29 @@ public sealed class FileSystemPhotoRepositoryTests
         // Assert
         Assert.AreEqual(1, countAfterFirst);
         Assert.AreEqual(2, countAfterSecond);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_WhenWriteFails_ThrowsStorageException()
+    {
+        // Arrange
+        var repository = new FileSystemPhotoRepository(_testBasePath, "TestEvent");
+        var photoId = Guid.Parse("550e8400-e29b-41d4-a716-446655440000");
+        var photo = new Photo
+        {
+            Id = photoId,
+            Code = "42",
+            CapturedAt = DateTime.UtcNow
+        };
+
+        // Occupy the exact target path with a directory so the file write fails
+        // (cross-platform: writing a file where a directory exists throws IOException
+        // or UnauthorizedAccessException, both of which the repository wraps).
+        var targetPath = Path.Combine(_testBasePath, "TestEvent", $"00042-{photoId}.jpg");
+        Directory.CreateDirectory(targetPath);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<StorageException>(
+            () => repository.SaveAsync(photo, new byte[] { 0xFF, 0xD8, 0xFF }));
     }
 }


### PR DESCRIPTION
Implements the three Group D findings from the codebase health check (#241): backend resilience around photo storage and capture, plus a small client-side fallback.

## #251 — Handle storage write failures (Medium)
- New StorageException : PhotoBoothException.
- FileSystemPhotoRepository.SaveAsync now catches IOException / UnauthorizedAccessException and wraps them in StorageException with an actionable message (preserving the inner exception). OperationCanceledException is deliberately not caught.
- Surfaced meaningfully: the /api/photos/capture endpoint returns HTTP 507 (Insufficient Storage), and the background workflow logs at Error and broadcasts a specific capture-failed SSE message instead of the generic one.

## #252 — In-memory cache never invalidated (Low)
- Documentation only, by decision: the issue lists documenting the single-process assumption as a valid resolution, and it fits the codebase's minimalism. Added a code comment above the cache field and a Storage Assumptions section to CLAUDE.md. No behavior change.

## #253 — Timeout broadcast swallowed / stuck booth UI (Low)
- Backend: elevated the swallowed timeout-broadcast log from Debug to Warning.
- Frontend: EventBroadcaster.BroadcastAsync is designed never to throw, so the real risk is the booth UI hanging on the countdown if a terminal event never arrives. Added a client-side capture watchdog in BoothPage that arms a timer per countdown-started (exceeds the server's max workflow timeout), cancels it when a terminal event arrives, and otherwise resets the UI with a transient 'Capture timed out' message. Factored the duplicated error-timeout logic into a showTransientError helper.

## Tests
- New unit test: SaveAsync throws StorageException when the write fails (deterministic, cross-platform — occupies the target path with a directory).
- New BoothPage vitest cases: watchdog clears a stuck countdown and shows a timeout error; a timely terminal event cancels the watchdog.
- Full suite green locally: dotnet (TestCategory!=Integration), vitest (144), eslint, and frontend build.

Closes #251
Closes #252
Closes #253