### PR TITLE
Group A: frontend accessibility

### DIFF
--- a/src/PhotoBooth.Web/src/App.css
+++ b/src/PhotoBooth.Web/src/App.css
@@ -47,7 +47,7 @@ body {
 .slideshow-empty,
 .slideshow-error {
   font-size: 2rem;
-  color: #666;
+  color: #8a8a8a;
 }
 
 /* Photo Display */
@@ -260,11 +260,12 @@ body {
 }
 
 .code-input::placeholder {
-  color: #666;
+  color: #8a8a8a;
 }
 
-.code-input:focus {
-  outline: none;
+.code-input:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 .search-button {
@@ -282,12 +283,13 @@ body {
 }
 
 .search-button:disabled {
-  color: #444;
+  color: #6e6e6e;
   cursor: not-allowed;
 }
 
-.search-button:focus {
-  outline: none;
+.search-button:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 .search-button:not(:disabled):active {
@@ -308,10 +310,23 @@ body {
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  /* Reset native <button> defaults so tiles look identical to the old divs */
+  border: none;
+  padding: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  display: block;
+  width: 100%;
 }
 
 .photo-grid-item:active {
   opacity: 0.8;
+}
+
+.photo-grid-item:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: -2px;
 }
 
 .photo-grid-item img {
@@ -324,7 +339,7 @@ body {
 .photo-grid-loading,
 .photo-grid-error,
 .photo-grid-empty {
-  color: #666;
+  color: #8a8a8a;
   font-size: 1.25rem;
   text-align: center;
   padding: 2rem;
@@ -442,12 +457,13 @@ body {
   opacity: 0.6;
 }
 
-.photo-detail-nav-arrow:focus {
-  outline: none;
+.photo-detail-nav-arrow:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 .photo-detail-loading {
-  color: #666;
+  color: #8a8a8a;
   font-size: 1.25rem;
   flex: 1;
   display: flex;
@@ -476,9 +492,10 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-.action-button:focus,
-.nav-back-button:focus {
-  outline: none;
+.action-button:focus-visible,
+.nav-back-button:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 .action-button:active {
@@ -577,7 +594,7 @@ body {
 .language-button {
   background: none;
   border: none;
-  color: #666;
+  color: #8a8a8a;
   font-size: 0.9rem;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
@@ -587,6 +604,11 @@ body {
 
 .language-button:hover {
   color: #fff;
+}
+
+.language-button:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
 }
 
 .language-button.active {
@@ -612,7 +634,7 @@ body {
 .not-found-code {
   font-size: 8rem;
   font-weight: 700;
-  color: #666;
+  color: #8a8a8a;
   line-height: 1;
 }
 
@@ -635,4 +657,27 @@ body {
 
 .not-found-link:hover {
   text-decoration: underline;
+}
+
+.not-found-link:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+/* Reduced motion: neutralize large/looping animations for motion-sensitive guests.
+   Photos still appear and transition instantly; loading states stay legible. */
+@media (prefers-reduced-motion: reduce) {
+  .photo-display.swirl,
+  .photo-display.swirl.fading-out,
+  .photo-display.fade,
+  .photo-display.fade.fading-out,
+  .photo-image.ken-burns,
+  .waiting-message,
+  .action-button.loading svg {
+    animation: none;
+  }
+
+  .speed-dial-item {
+    transition: none;
+  }
 }

--- a/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
+++ b/src/PhotoBooth.Web/src/components/PhotoGrid.tsx
@@ -112,9 +112,11 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
   return (
     <div className="photo-grid">
       {photos.map(photo => (
-        <div
+        <button
+          type="button"
           key={photo.id}
           className="photo-grid-item"
+          aria-label={`Photo ${photo.code}`}
           onClick={() => {
             setGalleryCache(photos, nextCursor, window.scrollY);
             savedViaClickRef.current = true;
@@ -126,7 +128,7 @@ export function PhotoGrid({ onPhotoClick }: PhotoGridProps) {
             alt={`Photo ${photo.code}`}
             loading="lazy"
           />
-        </div>
+        </button>
       ))}
       {nextCursor && (
         <div ref={sentinelRef} className="photo-grid-loading">

--- a/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
+++ b/src/PhotoBooth.Web/src/components/__tests__/PhotoGrid.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PhotoGrid } from '../PhotoGrid';
 import { getGalleryCache, setGalleryCache, __resetForTests } from '../galleryCache';
 import type { PhotoDto } from '../../api/types';
@@ -125,5 +126,40 @@ describe('PhotoGrid', () => {
     );
 
     expect(onPhotoClick).toHaveBeenCalledWith('1');
+  });
+
+  it('renders tiles as focusable buttons reachable by keyboard', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: null });
+
+    render(<PhotoGrid onPhotoClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    const tiles = screen.getAllByRole('button', { name: /^Photo / });
+    expect(tiles).toHaveLength(2);
+  });
+
+  it('activates a tile with the keyboard (Enter/Space)', async () => {
+    mockGetPhotosPage.mockResolvedValue({ photos: samplePhotos, nextCursor: null });
+    const onPhotoClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<PhotoGrid onPhotoClick={onPhotoClick} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+
+    const firstTile = screen.getAllByRole('button', { name: /^Photo / })[0];
+    firstTile.focus();
+    await user.keyboard('{Enter}');
+    expect(onPhotoClick).toHaveBeenCalledWith('1');
+
+    onPhotoClick.mockClear();
+    screen.getAllByRole('button', { name: /^Photo / })[1].focus();
+    await user.keyboard(' ');
+    expect(onPhotoClick).toHaveBeenCalledWith('2');
   });
 });

--- a/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/PhotoDetailPage.tsx
@@ -109,6 +109,45 @@ export function PhotoDetailPage({ urlPrefix }: PhotoDetailPageProps) {
 
   useSwipeNavigation({ onSwipeLeft: handleSwipeLeft, onSwipeRight: handleSwipeRight, elementRef: pageRef, disabled: isZoomed });
 
+  // Keyboard zoom/pan controls: +/- to zoom, 0 to reset, arrows to pan while zoomed.
+  useEffect(() => {
+    if (!photo) return;
+    const PAN_STEP = 60;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const ref = transformRef.current;
+      if (!ref) return;
+      switch (e.key) {
+        case '+':
+        case '=':
+          ref.zoomIn(0.5);
+          break;
+        case '-':
+        case '_':
+          ref.zoomOut(0.5);
+          break;
+        case '0':
+          ref.resetTransform();
+          break;
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight': {
+          const { scale, positionX, positionY } = ref.instance.state;
+          if (scale <= 1) return; // only pan when zoomed in
+          const x = e.key === 'ArrowLeft' ? positionX + PAN_STEP : e.key === 'ArrowRight' ? positionX - PAN_STEP : positionX;
+          const y = e.key === 'ArrowUp' ? positionY + PAN_STEP : e.key === 'ArrowDown' ? positionY - PAN_STEP : positionY;
+          ref.setTransform(x, y, scale);
+          break;
+        }
+        default:
+          return;
+      }
+      e.preventDefault();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [photo]);
+
   const handleToggle = async () => {
     if (photoAction === 'expanded') {
       setPhotoAction('idle');

--- a/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/PhotoDetailPage.test.tsx
@@ -32,9 +32,28 @@ vi.mock('../../hooks/useSwipeNavigation', () => ({
 type OnTransformFn = (ref: unknown, state: { scale: number }) => void;
 let capturedOnTransform: OnTransformFn | undefined;
 
+const { mockZoomIn, mockZoomOut, mockResetTransform, mockSetTransform, mockTransformState } = vi.hoisted(() => ({
+  mockZoomIn: vi.fn(),
+  mockZoomOut: vi.fn(),
+  mockResetTransform: vi.fn(),
+  mockSetTransform: vi.fn(),
+  mockTransformState: { scale: 1, positionX: 0, positionY: 0 },
+}));
+
+type TransformRef = ((api: unknown) => void) | { current: unknown } | null | undefined;
+
 vi.mock('react-zoom-pan-pinch', () => ({
-  TransformWrapper: ({ children, onTransform }: { children: React.ReactNode; onTransform?: OnTransformFn }) => {
+  TransformWrapper: ({ children, onTransform, ref }: { children: React.ReactNode; onTransform?: OnTransformFn; ref?: TransformRef }) => {
     capturedOnTransform = onTransform;
+    const api = {
+      zoomIn: mockZoomIn,
+      zoomOut: mockZoomOut,
+      resetTransform: mockResetTransform,
+      setTransform: mockSetTransform,
+      instance: { state: mockTransformState },
+    };
+    if (typeof ref === 'function') ref(api);
+    else if (ref) ref.current = api;
     return <>{children}</>;
   },
   TransformComponent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -82,6 +101,13 @@ describe('PhotoDetailPage', () => {
     mockNavigate.mockClear();
     swipeConfigSpy.mockClear();
     capturedOnTransform = undefined;
+    mockZoomIn.mockClear();
+    mockZoomOut.mockClear();
+    mockResetTransform.mockClear();
+    mockSetTransform.mockClear();
+    mockTransformState.scale = 1;
+    mockTransformState.positionX = 0;
+    mockTransformState.positionY = 0;
     mockGetPhotoByCode.mockResolvedValue(mockPhoto);
     mockGetAllPhotos.mockResolvedValue([mockPhoto]);
   });
@@ -312,5 +338,46 @@ describe('PhotoDetailPage', () => {
 
     expect(screen.queryByRole('button', { name: 'Previous photo' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Next photo' })).not.toBeInTheDocument();
+  });
+
+  it('zooms in when the + key is pressed', async () => {
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: '+' });
+    expect(mockZoomIn).toHaveBeenCalled();
+  });
+
+  it('zooms out when the - key is pressed', async () => {
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: '-' });
+    expect(mockZoomOut).toHaveBeenCalled();
+  });
+
+  it('resets the transform when the 0 key is pressed', async () => {
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: '0' });
+    expect(mockResetTransform).toHaveBeenCalled();
+  });
+
+  it('does not pan with arrow keys when not zoomed', async () => {
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(mockSetTransform).not.toHaveBeenCalled();
+  });
+
+  it('pans with arrow keys when zoomed in', async () => {
+    mockTransformState.scale = 2;
+    render(<PhotoDetailPage urlPrefix="testprefix" />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(mockSetTransform).toHaveBeenCalledWith(-60, 0, 2);
   });
 });


### PR DESCRIPTION
Implements the four frontend accessibility findings from health check #241, grouped into one PR because they all touch src/PhotoBooth.Web/src/ (App.css + components).

## Changes

- **#242 Respect prefers-reduced-motion.** Added a @media (prefers-reduced-motion: reduce) block that neutralizes the swirl, fade, Ken Burns, waiting-pulse, and spinner animations plus the speed-dial transition. The slideshow renders the incoming photo on top and removes the outgoing one after 500ms regardless of CSS, so reduced motion becomes a clean instant swap.
- **#243 Keyboard-navigable photo grid.** Each tile is now a native button (Enter/Space activate it natively), with button styling reset so it looks identical and an inset focus-visible ring.
- **#244 Keyboard zoom controls on the detail view.** A window keydown listener wired to the existing TransformWrapper ref: +/= zoom in, -/_ zoom out, 0 reset, arrow keys pan only when zoomed in (no-op at scale 1).
- **#245 Contrast audit + focus indicators.** Lightened failing greys (~#666) to #8a8a8a (verified >=4.5:1 on both #000 and #1a1a1a) and bumped the disabled search button to #6e6e6e. Replaced every bare outline: none with a :focus-visible outline and added focus rings to the language buttons and not-found link (app-wide focus visibility).

## Verification

- eslint clean
- 151 tests pass (added PhotoGrid keyboard-activation tests and PhotoDetailPage zoom-key tests)
- tsc -b and vite build succeed

Closes #242
Closes #243
Closes #244
Closes #245

Part of #241.