### PR TITLE
Group B: internationalize error messages (#246, #247)

### DIFF
--- a/src/PhotoBooth.Application/Events/CaptureErrorCodes.cs
+++ b/src/PhotoBooth.Application/Events/CaptureErrorCodes.cs
@@ -1,0 +1,13 @@
+namespace PhotoBooth.Application.Events;
+
+/// <summary>
+/// Stable, machine-readable codes for <see cref="CaptureFailedEvent"/>.
+/// The frontend maps these to localized strings; the event's English
+/// <c>Error</c> text remains as a fallback for non-localizing clients.
+/// </summary>
+public static class CaptureErrorCodes
+{
+    public const string Timeout = "capture-timed-out";
+    public const string StorageUnavailable = "storage-unavailable";
+    public const string CaptureFailed = "capture-failed";
+}

--- a/src/PhotoBooth.Application/Events/PhotoBoothEvent.cs
+++ b/src/PhotoBooth.Application/Events/PhotoBoothEvent.cs
@@ -25,9 +25,10 @@ public record PhotoCapturedEvent(
 }
 
 public record CaptureFailedEvent(
+    string Code,
     string Error,
     DateTime Timestamp) : PhotoBoothEvent("capture-failed", Timestamp)
 {
-    public CaptureFailedEvent(string error)
-        : this(error, Now) { }
+    public CaptureFailedEvent(string code, string error)
+        : this(code, error, Now) { }
 }

--- a/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
+++ b/src/PhotoBooth.Application/Services/CaptureWorkflowService.cs
@@ -78,7 +78,7 @@ public class CaptureWorkflowService : ICaptureWorkflowService
             try
             {
                 await _eventBroadcaster.BroadcastAsync(
-                    new CaptureFailedEvent("Capture timed out"),
+                    new CaptureFailedEvent(CaptureErrorCodes.Timeout, "Capture timed out"),
                     cancellationToken);
             }
             catch (Exception ex)
@@ -133,14 +133,14 @@ public class CaptureWorkflowService : ICaptureWorkflowService
         {
             _logger.LogError(ex, "Capture failed: could not save photo to storage");
             await _eventBroadcaster.BroadcastAsync(
-                new CaptureFailedEvent("Could not save photo — storage may be full or unavailable"),
+                new CaptureFailedEvent(CaptureErrorCodes.StorageUnavailable, "Could not save photo — storage may be full or unavailable"),
                 cancellationToken);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Capture failed");
             await _eventBroadcaster.BroadcastAsync(
-                new CaptureFailedEvent("Photo capture failed"),
+                new CaptureFailedEvent(CaptureErrorCodes.CaptureFailed, "Photo capture failed"),
                 cancellationToken);
         }
     }

--- a/src/PhotoBooth.Web/src/api/types.ts
+++ b/src/PhotoBooth.Web/src/api/types.ts
@@ -42,6 +42,7 @@ export interface PhotoCapturedEvent {
 
 export interface CaptureFailedEvent {
   eventType: 'capture-failed';
+  code: string;
   error: string;
   timestamp: string;
 }

--- a/src/PhotoBooth.Web/src/i18n/translations.ts
+++ b/src/PhotoBooth.Web/src/i18n/translations.ts
@@ -25,6 +25,12 @@ export const translations = {
     // Not found page
     pageNotFound: 'Page not found',
     goToGallery: 'Go to Gallery',
+
+    // Booth capture errors
+    captureTimedOut: 'Capture timed out',
+    storageUnavailable: 'Could not save photo — storage may be full or unavailable',
+    captureFailed: 'Photo capture failed',
+    failedToTriggerCapture: 'Failed to trigger capture',
   },
   es: {
     // Download page
@@ -52,6 +58,12 @@ export const translations = {
     // Not found page
     pageNotFound: 'Pagina no encontrada',
     goToGallery: 'Ir a la Galeria',
+
+    // Booth capture errors
+    captureTimedOut: 'Se agotó el tiempo de captura',
+    storageUnavailable: 'No se pudo guardar la foto — el almacenamiento puede estar lleno o no disponible',
+    captureFailed: 'Error al capturar la foto',
+    failedToTriggerCapture: 'No se pudo iniciar la captura',
   },
 } as const;
 

--- a/src/PhotoBooth.Web/src/pages/BoothPage.tsx
+++ b/src/PhotoBooth.Web/src/pages/BoothPage.tsx
@@ -10,6 +10,8 @@ import { useKeyboardNavigation } from '../hooks/useKeyboardNavigation';
 import { useGamepadNavigation } from '../hooks/useGamepadNavigation';
 import type { GamepadDebugEvent } from '../hooks/useGamepadNavigation';
 import type { PhotoBoothEvent, QueuedPhoto, GamepadConfig } from '../api/types';
+import { useTranslation } from '../i18n/useTranslation';
+import type { TranslationKey } from '../i18n/translations';
 
 const DEFAULT_SLIDESHOW_INTERVAL_MS = 30000;
 const DEFAULT_WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000;
@@ -22,6 +24,14 @@ const GAMEPAD_DEBUG_DISPLAY_MS = 3000;
 // timeout (Capture:CountdownDurationMs + Capture:BufferTimeoutHighLatencyMs, up to ~52s
 // for Android over ADB) to avoid false positives on slow but legitimate captures.
 const CAPTURE_WATCHDOG_MS = 60000;
+
+// Maps backend CaptureFailedEvent codes to translation keys. Unknown/future
+// codes fall back to the event's English `error` string.
+const CAPTURE_ERROR_KEYS: Record<string, TranslationKey> = {
+  'capture-timed-out': 'captureTimedOut',
+  'storage-unavailable': 'storageUnavailable',
+  'capture-failed': 'captureFailed',
+};
 
 interface BoothPageProps {
   qrCodeBaseUrl?: string;
@@ -40,6 +50,8 @@ interface DisplayPhoto {
 }
 
 export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, slideshowIntervalMs = DEFAULT_SLIDESHOW_INTERVAL_MS, gamepadConfig, watchdogTimeoutMs = DEFAULT_WATCHDOG_TIMEOUT_MS }: BoothPageProps) {
+  const { t } = useTranslation();
+
   // Queue of interrupted photos waiting to be displayed
   const [photoQueue, setPhotoQueue] = useState<QueuedPhoto[]>([]);
   // Current index within the queue
@@ -248,7 +260,7 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
           }
           console.warn('Capture watchdog fired: no terminal event received, resetting UI');
           setActiveCountdowns(count => Math.max(0, count - 1));
-          showTransientError('Capture timed out');
+          showTransientError(t('captureTimedOut'));
         }, CAPTURE_WATCHDOG_MS);
         captureWatchdogsRef.current.push(watchdogId);
 
@@ -274,14 +286,16 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
         break;
       }
 
-      case 'capture-failed':
+      case 'capture-failed': {
         console.error('Capture failed:', event.error);
         clearOldestCaptureWatchdog();
         setActiveCountdowns(count => Math.max(0, count - 1));
-        showTransientError(event.error);
+        const errorKey = CAPTURE_ERROR_KEYS[event.code];
+        showTransientError(errorKey ? t(errorKey) : event.error);
         break;
+      }
     }
-  }, [handleInterruption, startShowingPhoto, showTransientError, clearOldestCaptureWatchdog]);
+  }, [handleInterruption, startShowingPhoto, showTransientError, clearOldestCaptureWatchdog, t]);
 
   useEventStream(handleEvent);
 
@@ -293,9 +307,9 @@ export function BoothPage({ qrCodeBaseUrl, urlPrefix = '', swirlEffect = true, s
       await triggerCapture(durationMs);
     } catch (err) {
       console.error('Trigger error:', err);
-      showTransientError(err instanceof Error ? err.message : 'Failed to trigger capture');
+      showTransientError(t('failedToTriggerCapture'));
     }
-  }, [resetWatchdog, showTransientError]);
+  }, [resetWatchdog, showTransientError, t]);
 
   // Clear queue and dismiss current display
   const clearQueueAndDisplay = useCallback(() => {

--- a/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
+++ b/src/PhotoBooth.Web/src/pages/__tests__/BoothPage.test.tsx
@@ -70,8 +70,9 @@ const photoCapturedEvent = (): PhotoBoothEvent => ({
   timestamp: '2025-01-01T00:00:00Z',
 });
 
-const captureFailedEvent = (error = 'Camera error'): PhotoBoothEvent => ({
+const captureFailedEvent = (error = 'Camera error', code = ''): PhotoBoothEvent => ({
   eventType: 'capture-failed',
+  code,
   error,
   timestamp: '2025-01-01T00:00:00Z',
 });
@@ -109,13 +110,13 @@ describe('BoothPage', () => {
     expect(mockTriggerCapture).toHaveBeenCalledOnce();
   });
 
-  it('shows error message when triggerCapture rejects', async () => {
+  it('shows a localized error message when triggerCapture rejects', async () => {
     mockTriggerCapture.mockRejectedValue(new Error('Network error'));
     const { container } = render(<BoothPage watchdogTimeoutMs={60000} />);
     await act(async () => {
       fireEvent.click(container.querySelector('.booth-page')!);
     });
-    expect(screen.getByText('Network error')).toBeInTheDocument();
+    expect(screen.getByText('Failed to trigger capture')).toBeInTheDocument();
   });
 
   it('clears error message after 3000ms', async () => {
@@ -124,10 +125,10 @@ describe('BoothPage', () => {
     await act(async () => {
       fireEvent.click(container.querySelector('.booth-page')!);
     });
-    expect(screen.getByText('Network error')).toBeInTheDocument();
+    expect(screen.getByText('Failed to trigger capture')).toBeInTheDocument();
 
     act(() => { vi.advanceTimersByTime(3000); });
-    expect(screen.queryByText('Network error')).not.toBeInTheDocument();
+    expect(screen.queryByText('Failed to trigger capture')).not.toBeInTheDocument();
   });
 
   it('shows CaptureOverlay when countdown-started event arrives', () => {
@@ -151,10 +152,17 @@ describe('BoothPage', () => {
     expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
   });
 
-  it('shows error message on capture-failed event', () => {
+  it('shows the localized message for a known capture-failed code', () => {
     render(<BoothPage watchdogTimeoutMs={60000} />);
     act(() => { capturedOnEvent!(countdownEvent()); });
-    act(() => { capturedOnEvent!(captureFailedEvent('Camera error')); });
+    act(() => { capturedOnEvent!(captureFailedEvent('Photo capture failed', 'capture-failed')); });
+    expect(screen.getByText('Photo capture failed')).toBeInTheDocument();
+  });
+
+  it('falls back to the server error string for an unknown capture-failed code', () => {
+    render(<BoothPage watchdogTimeoutMs={60000} />);
+    act(() => { capturedOnEvent!(countdownEvent()); });
+    act(() => { capturedOnEvent!(captureFailedEvent('Camera error', 'some-future-code')); });
     expect(screen.getByText('Camera error')).toBeInTheDocument();
   });
 

--- a/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
+++ b/tests/PhotoBooth.Application.Tests/CaptureWorkflowServiceTests.cs
@@ -102,6 +102,7 @@ public sealed class CaptureWorkflowServiceTests
 
         var failedEvent = _eventBroadcaster.BroadcastedEvents[1] as CaptureFailedEvent;
         Assert.IsNotNull(failedEvent);
+        Assert.AreEqual(CaptureErrorCodes.CaptureFailed, failedEvent.Code);
         Assert.AreEqual("Photo capture failed", failedEvent.Error);
     }
 


### PR DESCRIPTION
Part of the codebase health check (#241), Group B.

The booth has complete EN/ES localization for its UI, but error messages were English-only — breaking the Spanish experience exactly when something goes wrong. This PR localizes every error a guest can see on the booth.

## Backend (#246)

Attach a stable machine-readable `Code` to `CaptureFailedEvent` (`capture-timed-out`, `storage-unavailable`, `capture-failed`) via a new `CaptureErrorCodes` constants class. The existing English `Error` string stays as a fallback for non-localizing clients and for logging. The three broadcast sites in `CaptureWorkflowService` now pass a code. SSE serialization is reflection-based, so the new field flows to clients automatically.

## Frontend (#247)

`BoothPage` now uses `useTranslation`:
- `capture-failed` event codes map to EN/ES keys in `translations.ts`, falling back to the server's English `error` string for unknown/future codes.
- The client-side watchdog timeout and the trigger-failure fallback are localized (the latter previously surfaced a non-localizable `err.message` like 'Failed to trigger capture: Not Found').

## Scope

Limited to the SSE `capture-failed` path — the only backend errors a guest actually sees. The `/photos/capture` ProblemDetails and the `durationMs` validation message are never displayed (`client.ts` reads only `response.statusText` and discards the body), so adding codes there would be dead code with no consumer. Left untouched by design.

## Verification

- `dotnet test` — 115 unit tests pass
- Frontend vitest — 152 pass (added coverage for known-code translation and unknown-code fallback)
- `tsc -b` clean, `vite build` succeeds, eslint clean

Closes #246
Closes #247