### PR TITLE
Upgrade WiX toolset from 5.0.2 to 7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,68 @@ jobs:
       - name: Build frontend
         working-directory: src/PhotoBooth.Web
         run: pnpm run build
+
+  # The MSI installer (WiX) is not part of PhotoBooth.slnx and is otherwise only
+  # built in release.yml on tag publish, so installer/WiX drift stays hidden until a
+  # release breaks. This job builds the MSI on every PR to catch that early. WiX only
+  # supports Windows, so it must run on windows-latest. It mirrors the publish + MSI
+  # steps in release.yml (keep them in sync). It validates the build and ICE validation;
+  # runtime install/upgrade behavior is still only verified at release time on Windows.
+  installer:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/*.wixproj', 'Directory.Packages.props') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          package_json_file: src/PhotoBooth.Web/package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: src/PhotoBooth.Web/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: src/PhotoBooth.Web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: src/PhotoBooth.Web
+        run: pnpm run build
+
+      - name: Publish server for Windows x64
+        run: >
+          dotnet publish src/PhotoBooth.Server/PhotoBooth.Server.csproj
+          -c Release
+          -r win-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -o publish/win-x64
+
+      - name: Restore WiX installer
+        run: dotnet restore installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
+
+      - name: Build MSI installer
+        run: >
+          dotnet build installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
+          --configuration Release
+          -p:InstallerVersion=0.0.1
+          "-p:PublishDir=${{ github.workspace }}\publish\win-x64\"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ The public photo-code lookup `GET /api/photos/{code}` has a separate **per-IP** 
 
 GitHub Actions workflows in `.github/workflows/`:
 
-- **ci.yml**: Runs on PRs and pushes to main. Builds .NET and frontend, runs tests, and lints.
+- **ci.yml**: Runs on PRs and pushes to main. Builds .NET and frontend, runs tests, and lints. A separate `installer` job (Windows runner) also builds the MSI on every PR so WiX/installer drift is caught early instead of only at release time (it does not install/upgrade — that is still release-time only).
 - **release.yml**: Triggered when a release is published via the GitHub UI. Builds and uploads the Windows x64 standalone zip and MSI installer to the release.
 
 ### Creating a Release
@@ -170,11 +170,15 @@ GitHub Actions workflows in `.github/workflows/`:
 
 ## Installer
 
-WiX v5 MSI installer in `installer/PhotoBooth.Installer/`. Per-user install (`Scope="perUser"`, no admin/UAC) to `%LOCALAPPDATA%\PhotoBooth`. Major upgrade; installing a newer version replaces the existing one.
+WiX v7 MSI installer in `installer/PhotoBooth.Installer/`. Per-user install (`Scope="perUser"`, no admin/UAC) to `%LOCALAPPDATA%\PhotoBooth`. Major upgrade; installing a newer version replaces the existing one.
 
-Build manually (after publishing the server):
+**WiX only builds on Windows** — `dotnet build` of the wixproj fails on macOS/Linux (`wix.exe exited with code 1`, "only supports Windows"). This has always been the case (v5 and v7 alike); build the MSI on Windows or via CI/release.
+
+WiX v7 requires accepting the [Open Source Maintenance Fee EULA](https://docs.firegiant.com/wix/osmf/). Acceptance is free and handled non-interactively by `<AcceptEula>wix7</AcceptEula>` in the wixproj, so no manual step or env var is needed in CI.
+
+Build manually on Windows (after publishing the server). Pass an **absolute** `PublishDir` — under WiX v7 relative `Files` paths resolve against the `.wxs` source directory, not the working directory:
 ```bash
-dotnet build installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj --configuration Release -p:InstallerVersion=1.2.3 "-p:PublishDir=publish\win-x64\"
+dotnet build installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj --configuration Release -p:InstallerVersion=1.2.3 "-p:PublishDir=%CD%\publish\win-x64\"
 ```
 
 The version is extracted from the git tag in the release workflow (strips `v` prefix and semver prerelease/build metadata).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- WiX Installer -->
-    <PackageVersion Include="WixToolset.UI.wixext" Version="5.0.2" />
+    <PackageVersion Include="WixToolset.UI.wixext" Version="7.0.0" />
     <!-- Camera -->
     <PackageVersion Include="OpenCvSharp4" Version="4.13.0.20260602" />
     <PackageVersion Include="OpenCvSharp4.runtime.osx_arm64" Version="4.8.1-rc" />

--- a/docs/adr/0004-per-user-msi-and-user-settings.md
+++ b/docs/adr/0004-per-user-msi-and-user-settings.md
@@ -12,7 +12,7 @@ Standard ASP.NET Core practice is to ship a default `appsettings.json` that gets
 
 ## Decision
 
-**Installer scope:** The WiX v5 MSI installer (`installer/PhotoBooth.Installer/`) uses `Scope="perUser"`, installing to `%LOCALAPPDATA%\PhotoBooth`. No UAC elevation prompt is shown; no administrator rights are required.
+**Installer scope:** The WiX MSI installer (`installer/PhotoBooth.Installer/`) uses `Scope="perUser"`, installing to `%LOCALAPPDATA%\PhotoBooth`. No UAC elevation prompt is shown; no administrator rights are required.
 
 **Configuration layering:** On startup, the server loads configuration from two files in the install directory:
 1. `appsettings.json` — shipped defaults, overwritten on every upgrade.

--- a/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
+++ b/installer/PhotoBooth.Installer/PhotoBooth.Installer.wixproj
@@ -1,12 +1,16 @@
-<Project Sdk="WixToolset.Sdk/5.0.2">
+<Project Sdk="WixToolset.Sdk/7.0.0">
   <PropertyGroup>
     <InstallerVersion Condition="'$(InstallerVersion)' == ''">0.0.1</InstallerVersion>
+    <!-- WiX v7 requires accepting the Open Source Maintenance Fee EULA. Acceptance is
+         free (the fee is a voluntary sponsorship model); this enables non-interactive
+         CI/release builds. See https://docs.firegiant.com/wix/osmf/ -->
+    <AcceptEula>wix7</AcceptEula>
     <InstallerPlatform>x64</InstallerPlatform>
     <PublishDir Condition="'$(PublishDir)' == ''">..\..\publish\win-x64\</PublishDir>
     <DefineConstants>ProductVersion=$(InstallerVersion);PublishDir=$(PublishDir)</DefineConstants>
     <SuppressIces>ICE38;ICE40;ICE61;ICE64;ICE91</SuppressIces>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #256

## What

Upgrades the WiX installer toolset from **5.0.2** to **7.0.0** (current stable, two majors ahead) and adds an installer build to PR CI so WiX/installer drift is caught early instead of only at release time.

### Version bumps (three pins)
- `Directory.Packages.props` — `WixToolset.UI.wixext` 5.0.2 → 7.0.0
- `PhotoBooth.Installer.wixproj` — SDK `WixToolset.Sdk/5.0.2` → `7.0.0` and the `PackageReference` version

WiX v6 and v7 keep the v4 schema namespace (`http://wixtoolset.org/schemas/v4/wxs`), so `Package.wxs` is unchanged. Build requires .NET SDK 6+; we run .NET 10.

### WiX v7 EULA
WiX v7 enforces the [Open Source Maintenance Fee EULA](https://docs.firegiant.com/wix/osmf/) (error WIX7015 otherwise). Acceptance is free — the fee is a voluntary sponsorship model. Accepted non-interactively via `<AcceptEula>wix7</AcceptEula>` in the wixproj, which covers both CI and release builds.

### PR CI installer job
New `installer` job in `ci.yml` on `windows-latest` that publishes the server and builds the MSI on every PR. The installer wixproj is not in `PhotoBooth.slnx` and was previously only built in `release.yml` on tag publish, so breakage was hidden until a release. WiX only builds on Windows (true for v5 and v7 alike — verified locally), hence the Windows runner. The job validates the build and ICE validation; runtime install/upgrade behavior remains a release-time/manual concern on Windows.

### Docs
- `CLAUDE.md` — v7, the new CI job, the EULA note, Windows-only build note, and an absolute `PublishDir` in the manual command (v7 resolves relative `Files` paths against the `.wxs` source dir)
- ADR 0004 — softened the incidental `WiX v5` reference to be version-agnostic

## Verification
- v7 packages restore cleanly; the `AcceptEula` property clears WIX7015 locally.
- Confirmed v5 also fails to build on macOS, so the Windows-only constraint is pre-existing, not introduced here.
- The new Windows CI job validates the actual MSI build on this PR.
- Full per-user install + major-upgrade validation remains a Windows/release-time step (unchanged).