### PR TITLE
Use Assert.Contains instead of Assert.IsTrue boolean assertions

### DIFF
--- a/tests/PhotoBooth.Infrastructure.Tests/Camera/AdbServiceTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Camera/AdbServiceTests.cs
@@ -231,8 +231,8 @@ public sealed class AdbServiceTests
         var files = await _service.ListFilesAsync("/sdcard/DCIM/Camera");
 
         Assert.HasCount(2, files);
-        Assert.IsTrue(files.ContainsKey("photo.jpg"));
-        Assert.IsTrue(files.ContainsKey("another.jpg"));
+        Assert.Contains("photo.jpg", files.Keys);
+        Assert.Contains("another.jpg", files.Keys);
     }
 
     [TestMethod]

--- a/tests/PhotoBooth.Infrastructure.Tests/Imaging/OpenCvImageResizerTests.cs
+++ b/tests/PhotoBooth.Infrastructure.Tests/Imaging/OpenCvImageResizerTests.cs
@@ -157,8 +157,8 @@ public sealed class OpenCvImageResizerTests
 
         var cacheFiles = Directory.GetFiles(_cacheDirectory, $"{photoId}_*.jpg");
         Assert.HasCount(2, cacheFiles);
-        Assert.IsTrue(cacheFiles.Any(f => f.Contains("_200.jpg")), "200px thumbnail should exist");
-        Assert.IsTrue(cacheFiles.Any(f => f.Contains("_400.jpg")), "400px thumbnail should exist");
+        Assert.Contains(f => f.Contains("_200.jpg"), cacheFiles, "200px thumbnail should exist");
+        Assert.Contains(f => f.Contains("_400.jpg"), cacheFiles, "400px thumbnail should exist");
     }
 
     [TestMethod]


### PR DESCRIPTION
Replaces weak boolean assertions in two test files with Assert.Contains, aligning them with the project's documented MSTest assertion conventions (CLAUDE.md). Assert.IsTrue failures only report true vs false; Assert.Contains reports the expected value and the actual collection contents.

- AdbServiceTests.cs: Assert.IsTrue(files.ContainsKey(...)) becomes Assert.Contains(key, files.Keys).
- OpenCvImageResizerTests.cs: Assert.IsTrue(cacheFiles.Any(f => f.Contains(...))) becomes the predicate overload Assert.Contains(predicate, collection, message), preserving the existing messages.

No production code changes. All 115 unit tests pass.

Closes #258